### PR TITLE
[ON-186]  문항 생성 페이지에서 뒤로가면 제목과 설명 인풋이 전부 보이게 설정

### DIFF
--- a/src/pages/form/FormTitleStep.tsx
+++ b/src/pages/form/FormTitleStep.tsx
@@ -1,5 +1,6 @@
 import { adaptive } from "@toss/tds-colors";
 import { FixedBottomCTA, TextArea, Top } from "@toss/tds-mobile";
+import { useEffect, useRef } from "react";
 import { useMultiStep } from "../../contexts/MultiStepContext";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { createSurvey, patchSurvey } from "../../service/form";
@@ -15,6 +16,24 @@ export const FormTitleStep = () => {
 	const { handleStepChange } = useMultiStep();
 
 	const step = state.titleStepCompleted;
+	const hasInitialized = useRef(false);
+
+	useEffect(() => {
+		if (
+			!hasInitialized.current &&
+			!state.titleStepCompleted &&
+			state.survey.title.trim() &&
+			state.survey.description.trim()
+		) {
+			setTitleStepCompleted(true);
+			hasInitialized.current = true;
+		}
+	}, [
+		state.titleStepCompleted,
+		state.survey.title,
+		state.survey.description,
+		setTitleStepCompleted,
+	]);
 
 	const handleTitleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
 		setTitle(e.target.value);


### PR DESCRIPTION
feat: 문항 생성 페이지에서 뒤로가면 제목과 설명 인풋이 전부 보이게 설 설정

## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 문항 생성 페이지에서 뒤로가면 제목과 설명 인풋이 전부 보이게 설정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: https://linear.app/on-survey/issue/ON-186/문항생성-페이지에서-뒤로-가면-제목과-설명이-전부-보이게-설정


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->

https://github.com/user-attachments/assets/468cf6f4-d895-4122-9d1e-59e6ace30b71

