### PR TITLE
[ON-213] RATING, NPS answerMap 처리 및 결과 페이지 세로 레이아웃 변경

### DIFF
--- a/src/hooks/useSurveyAnswerDetail.ts
+++ b/src/hooks/useSurveyAnswerDetail.ts
@@ -40,8 +40,10 @@ export const useSurveyAnswerDetail = (
 
 		const questions = answerDetails.detailInfoList.map((detail) => {
 			const questionType = mapApiQuestionTypeToComponentType(detail.type);
+			// CHOICE와 RATING 타입은 answerMap 사용
 			const responseCount =
-				detail.type === "CHOICE" && detail.answerMap
+				(detail.type === "CHOICE" || detail.type === "RATING") &&
+				detail.answerMap
 					? Object.values(detail.answerMap).reduce(
 							(sum, count) => sum + count,
 							0,

--- a/src/hooks/useSurveyAnswerDetail.ts
+++ b/src/hooks/useSurveyAnswerDetail.ts
@@ -40,9 +40,10 @@ export const useSurveyAnswerDetail = (
 
 		const questions = answerDetails.detailInfoList.map((detail) => {
 			const questionType = mapApiQuestionTypeToComponentType(detail.type);
-			// CHOICE와 RATING 타입은 answerMap 사용
 			const responseCount =
-				(detail.type === "CHOICE" || detail.type === "RATING") &&
+				(detail.type === "CHOICE" ||
+					detail.type === "RATING" ||
+					detail.type === "NPS") &&
 				detail.answerMap
 					? Object.values(detail.answerMap).reduce(
 							(sum, count) => sum + count,

--- a/src/pages/mysurvey/SurveyResponseDetail.tsx
+++ b/src/pages/mysurvey/SurveyResponseDetail.tsx
@@ -69,9 +69,10 @@ export const SurveyResponseDetail = () => {
 
 		const path = getQuestionResultRoute(type);
 
-		// CHOICE와 RATING 타입은 answerMap 사용
 		const responseCount =
-			(questionDetail.type === "CHOICE" || questionDetail.type === "RATING") &&
+			(questionDetail.type === "CHOICE" ||
+				questionDetail.type === "RATING" ||
+				questionDetail.type === "NPS") &&
 			questionDetail.answerMap
 				? Object.values(questionDetail.answerMap).reduce(
 						(sum, count) => sum + count,

--- a/src/pages/mysurvey/SurveyResponseDetail.tsx
+++ b/src/pages/mysurvey/SurveyResponseDetail.tsx
@@ -69,8 +69,10 @@ export const SurveyResponseDetail = () => {
 
 		const path = getQuestionResultRoute(type);
 
+		// CHOICE와 RATING 타입은 answerMap 사용
 		const responseCount =
-			questionDetail.type === "CHOICE" && questionDetail.answerMap
+			(questionDetail.type === "CHOICE" || questionDetail.type === "RATING") &&
+			questionDetail.answerMap
 				? Object.values(questionDetail.answerMap).reduce(
 						(sum, count) => sum + count,
 						0,

--- a/src/pages/result/RatingResultPage.tsx
+++ b/src/pages/result/RatingResultPage.tsx
@@ -6,18 +6,10 @@ import {
 } from "../../constants/survey";
 import { useResultPageData } from "../../hooks/useResultPageData";
 
-const getBarHeight = (count: number, maxCount: number) => {
-	if (maxCount <= 0) {
-		return "0px";
-	}
-	const ratio = count / maxCount;
-	const height = 72 + ratio * 140;
-	return `${Math.round(height)}px`;
-};
-
 export const RatingResultPage = () => {
 	const {
 		question,
+		answerMap,
 		answerList,
 		surveyTitle,
 		surveyStatus,
@@ -27,19 +19,32 @@ export const RatingResultPage = () => {
 
 	const badge = SURVEY_BADGE_CONFIG[surveyStatus];
 	const ratingCount = question?.rate ?? 10;
-	const scores = answerList
-		.map((answer) => Number(answer))
-		.filter(
-			(score) => !Number.isNaN(score) && score >= 1 && score <= ratingCount,
-		);
+
+	const scores =
+		answerMap && Object.keys(answerMap).length > 0
+			? Object.entries(answerMap)
+					.flatMap(([score, count]) => Array(count).fill(Number(score)))
+					.filter(
+						(score) =>
+							!Number.isNaN(score) && score >= 1 && score <= ratingCount,
+					)
+			: answerList
+					.map((answer) => Number(answer))
+					.filter(
+						(score) =>
+							!Number.isNaN(score) && score >= 1 && score <= ratingCount,
+					);
 
 	const ratingDistribution = Array.from({ length: ratingCount }, (_, idx) => {
 		const score = idx + 1;
-		const count = scores.filter((s) => s === score).length;
+		const count =
+			answerMap && Object.keys(answerMap).length > 0
+				? Number(answerMap[String(score)] || 0)
+				: scores.filter((s) => s === score).length;
 		return { score, count, label: `${score}점` };
-	}).sort((a, b) => b.count - a.count || b.score - a.score);
+	});
 
-	const maxCount = ratingDistribution[0]?.count ?? 0;
+	const maxCount = Math.max(...ratingDistribution.map((r) => r.count), 0);
 	const average =
 		scores.length > 0
 			? scores.reduce((sum, score) => sum + score, 0) / scores.length
@@ -81,47 +86,47 @@ export const RatingResultPage = () => {
 				}
 			/>
 
-			<div className="px-6 pb-12 flex justify-center">
-				{scores.length === 0 || maxCount === 0 ? (
-					<div className="py-8 text-center">
-						<p className="text-gray-500">아직 응답이 없습니다.</p>
-					</div>
-				) : (
-					<div className="flex items-end gap-4">
-						{ratingDistribution.map((item) => {
-							const isTop = item.count === maxCount && maxCount > 0;
-							return (
-								<div
-									key={item.score}
-									className="flex flex-col items-center gap-2"
+			<div className="px-6 pb-12">
+				<div className="flex flex-col gap-3">
+					{ratingDistribution.map((item) => {
+						const isTop = item.count === maxCount && maxCount > 0;
+						const barWidth =
+							maxCount > 0 ? Math.max((item.count / maxCount) * 100, 0) : 0;
+						const minWidth = 4;
+						const finalWidth = barWidth > 0 ? `${barWidth}%` : `${minWidth}px`;
+
+						return (
+							<div key={item.score} className="flex items-center gap-4">
+								<Text
+									color={isTop ? adaptive.blue500 : adaptive.grey600}
+									typography="t6"
+									fontWeight="semibold"
+									className="w-12"
 								>
-									<Text
-										color={isTop ? adaptive.blue500 : adaptive.grey600}
-										typography="t6"
-										fontWeight="semibold"
-									>
-										{item.label}
-									</Text>
+									{item.label}
+								</Text>
+								<div className="flex-1 flex items-center gap-2">
 									<div
-										className={`w-8 rounded-full shadow-sm ${
+										className={`h-8 rounded-full shadow-sm ${
 											isTop
-												? "bg-gradient-to-t from-blue-200 via-blue-400 to-blue-500"
-												: "bg-gradient-to-t from-gray-200 via-gray-300 to-gray-400"
+												? "bg-gradient-to-r from-blue-200 via-blue-400 to-blue-500"
+												: "bg-gradient-to-r from-gray-200 via-gray-300 to-gray-400"
 										}`}
-										style={{ height: getBarHeight(item.count, maxCount) }}
+										style={{ width: finalWidth }}
 									/>
 									<Text
 										color={adaptive.grey700}
 										typography="t7"
 										fontWeight="medium"
+										className="w-12 text-right"
 									>
 										{item.count}명
 									</Text>
 								</div>
-							);
-						})}
-					</div>
-				)}
+							</div>
+						);
+					})}
+				</div>
 			</div>
 		</div>
 	);


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- RATING, NPS answerMap 처리 및 결과 페이지 세로 레이아웃 변경

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: https://linear.app/on-survey/issue/ON-213/설문-응답-평가형-nps-map-으로-변경


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->
- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

이전에는 평가형, NPS 타입은 answerList 배열에서 점수를 추출해 scores 배열을 만들고 reduce로 scoreMap 객체를 생성해 각 점수별 개수를 계산했습니다.
현재는, 평가형, NPS 타입도 answerMap을 사용하도록 변경했습니다. answerMap이 있으면 각 점수의 count를 직접 사용하고, 없을 때만 answerList를 fallback으로 사용하도록 수정했습니다.


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->
<img width="385" height="654" alt="스크린샷 2025-12-16 오후 4 27 51" src="https://github.com/user-attachments/assets/87c09a97-763f-40f7-b089-4ebf1918f4dc" />
