### PR TITLE
[SUR-57] 문항 수정시 API 요청 안 갈 수 있도록 코드 수정

### DIFF
--- a/src/pages/QuestionForm/DatePage.tsx
+++ b/src/pages/QuestionForm/DatePage.tsx
@@ -53,7 +53,8 @@ export const DatePage = () => {
 	};
 
 	const handleSubmit = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -70,9 +71,11 @@ export const DatePage = () => {
 			{
 				onSuccess: (result) => {
 					if (result.success && typeof result !== "string") {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/FormTitleStep.tsx
+++ b/src/pages/QuestionForm/FormTitleStep.tsx
@@ -2,6 +2,7 @@ import { adaptive } from "@toss/tds-colors";
 import { FixedBottomCTA, TextArea, Top } from "@toss/tds-mobile";
 import { useEffect, useState } from "react";
 import { useMultiStep } from "../../contexts/MultiStepContext";
+import { queryClient } from "../../contexts/queryClient";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { useCreateSurvey, usePatchSurvey } from "./hooks/useSurveyMutation";
 
@@ -49,6 +50,7 @@ export const FormTitleStep = () => {
 					onSuccess: (data) => {
 						setSurveyId(data.result.surveyId);
 						setSurveyStep(1);
+						queryClient.invalidateQueries({ queryKey: ["userSurveys"] });
 					},
 					onError: (error) => {
 						console.error("설문 수정 실패:", error);

--- a/src/pages/QuestionForm/LongAnswerPage.tsx
+++ b/src/pages/QuestionForm/LongAnswerPage.tsx
@@ -36,7 +36,8 @@ export const LongAnswerPage = () => {
 	};
 
 	const handleSubmit = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -52,10 +53,12 @@ export const LongAnswerPage = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/NPSPage.tsx
+++ b/src/pages/QuestionForm/NPSPage.tsx
@@ -47,7 +47,8 @@ export const NPSPage = () => {
 	};
 
 	const handleConfirm = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -63,10 +64,12 @@ export const NPSPage = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/NumberPage.tsx
+++ b/src/pages/QuestionForm/NumberPage.tsx
@@ -36,7 +36,8 @@ export const NumberPage = () => {
 	};
 
 	const handleSubmit = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -52,10 +53,12 @@ export const NumberPage = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/RatingPage.tsx
+++ b/src/pages/QuestionForm/RatingPage.tsx
@@ -94,7 +94,8 @@ export const RatingPage = () => {
 	};
 
 	const handleConfirm = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -110,10 +111,12 @@ export const RatingPage = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/ShortAnswerPage.tsx
+++ b/src/pages/QuestionForm/ShortAnswerPage.tsx
@@ -36,7 +36,8 @@ export const ShortAnswerPage = () => {
 	};
 
 	const handleConfirm = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -52,10 +53,12 @@ export const ShortAnswerPage = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}

--- a/src/pages/QuestionForm/components/controller/FormController.tsx
+++ b/src/pages/QuestionForm/components/controller/FormController.tsx
@@ -10,6 +10,7 @@ import {
 	TEXT_PROPS,
 } from "../../../../constants/formController";
 import { useMultiStep } from "../../../../contexts/MultiStepContext";
+import { queryClient } from "../../../../contexts/queryClient";
 import { useSurvey } from "../../../../contexts/SurveyContext";
 import { useModal } from "../../../../hooks/UseToggle";
 import { convertQuestionsToServerFormat } from "../../../../utils/questionConverter";
@@ -66,6 +67,7 @@ export const FormController = ({
 				onSuccess: (result) => {
 					if (result.success) {
 						handleConfirmDialogOpen();
+						queryClient.invalidateQueries({ queryKey: ["userSurveys"] });
 					}
 				},
 				onError: (error) => {
@@ -116,6 +118,7 @@ export const FormController = ({
 								"https://static.toss.im/lotties-common/check-green-spot.json",
 							higherThanCTA: true,
 						});
+						queryClient.invalidateQueries({ queryKey: ["userSurveys"] });
 					}
 				},
 				onError: (error) => {

--- a/src/pages/QuestionForm/multipleChoice/MultipleChoiceMain.tsx
+++ b/src/pages/QuestionForm/multipleChoice/MultipleChoiceMain.tsx
@@ -23,8 +23,14 @@ export const MultipleChoiceMain = () => {
 
 	const navigate = useNavigate();
 
-	const { question, questionId, isRequired, title, description } =
-		useQuestionByType("multipleChoice");
+	const {
+		question,
+		questionId,
+		questionIdFromUrl,
+		isRequired,
+		title,
+		description,
+	} = useQuestionByType("multipleChoice");
 
 	const maxChoice = question?.maxChoice;
 	const options = question?.option ?? [];
@@ -74,7 +80,8 @@ export const MultipleChoiceMain = () => {
 	};
 
 	const handleConfirm = () => {
-		if (!questionId) {
+		if (questionIdFromUrl) {
+			navigate(-1);
 			return;
 		}
 
@@ -90,10 +97,12 @@ export const MultipleChoiceMain = () => {
 			},
 			{
 				onSuccess: (result) => {
-					if (result.success) {
-						updateQuestion(questionId, {
-							questionId: result.result.questionId,
-						});
+					if (result.success && typeof result !== "string") {
+						if (questionId) {
+							updateQuestion(questionId, {
+								questionId: result.result.questionId,
+							});
+						}
 
 						navigate(-1);
 					}


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 문항 수정시 API 요청 안 갈 수 있도록 코드 수정
- 설문 생성, 임시저장, 설문 작성 완료 후 나의 설문 캐싱 데이터 초기화되도록 변경

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: https://onsurvey.atlassian.net/browse/SUR-57

 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 질문 편집 시 폼 제출 흐름을 개선하여 URL 기반 질문 ID 인식이 정확해졌습니다.
  * 새 질문 생성 중 잘못된 업데이트를 방지하기 위해 조건부 검증을 강화했습니다.
  * 양식 제출 후 설문 데이터가 올바르게 새로고침되도록 캐시 무효화 로직을 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->