### PR TITLE
[SUR-72] 온보딩 상태 확인 로직 개선 및 isOnboardingCompleted 필드 반영

### DIFF
--- a/src/hooks/useUserSurveys.ts
+++ b/src/hooks/useUserSurveys.ts
@@ -50,18 +50,12 @@ export const useUserSurveys = () => {
 			}));
 
 		const closed: ClosedSurvey[] = userSurveys
-			.filter((survey): survey is typeof survey & { deadLine: string } => {
-				if (!survey.deadLine) return false;
-				if (draftStatuses.has(survey.status)) return false;
-				if (survey.status === "ONGOING") return false;
-				const deadline = new Date(survey.deadLine);
-				return deadline <= now;
-			})
+			.filter((survey) => survey.status === "CLOSED")
 			.map((survey) => ({
 				id: survey.surveyId,
 				title: survey.title,
 				description: survey.description,
-				closedAt: survey.deadLine,
+				closedAt: survey.deadLine ?? undefined,
 			}));
 
 		return {

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -14,8 +14,13 @@ export const Intro = () => {
 	useEffect(() => {
 		const checkAuth = async () => {
 			try {
-				await getMemberInfo();
-				navigate("/home", { replace: true });
+				const memberInfo = await getMemberInfo();
+				// 온보딩 완료된 사용자는 홈으로, 미완료 사용자는 온보딩으로
+				if (memberInfo.onboardingCompleted) {
+					navigate("/home", { replace: true });
+				} else {
+					navigate("/onboarding", { replace: true });
+				}
 			} catch (error) {
 				// 인증 실패 (토큰 없거나 만료 등) 시에는 로그인 페이지 유지
 				console.error("자동 로그인 확인 실패:", error);

--- a/src/pages/Intro.tsx
+++ b/src/pages/Intro.tsx
@@ -15,8 +15,8 @@ export const Intro = () => {
 		const checkAuth = async () => {
 			try {
 				const memberInfo = await getMemberInfo();
-				// 온보딩 완료된 사용자는 홈으로, 미완료 사용자는 온보딩으로
-				if (memberInfo.onboardingCompleted) {
+				// isOnboardingCompleted 상태에 따라 분기
+				if (memberInfo.isOnboardingCompleted) {
 					navigate("/home", { replace: true });
 				} else {
 					navigate("/onboarding", { replace: true });
@@ -38,6 +38,7 @@ export const Intro = () => {
 					loginApiResponse.accessToken,
 					loginApiResponse.refreshToken,
 				);
+				// 로그인 API 응답에 onboardingCompleted가 포함되어 있음
 				if (loginApiResponse.onboardingCompleted) {
 					navigate("/home", { replace: true });
 				} else {

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from "react-router-dom";
 import { ExitConfirmDialog } from "../components/ExitConfirmDialog";
 import { type RegionData, regions } from "../constants/regions";
 import { type TopicData, topics } from "../constants/topics";
+import { useUserInfo } from "../contexts/UserContext";
 import { useModal } from "../hooks/UseToggle";
 import { useBackEventListener } from "../hooks/useBackEventListener";
 import { OnboardingApi } from "../service/onboading";
@@ -107,6 +108,7 @@ const OnboardingStep2 = ({
 	handleTopicToggle: (topic: TopicData) => void;
 }) => {
 	const navigate = useNavigate();
+	const { fetchUserInfo } = useUserInfo();
 
 	const handleSubmit = async () => {
 		if (!selectedRegion) return;
@@ -121,6 +123,8 @@ const OnboardingStep2 = ({
 		});
 
 		if (response.success) {
+			// 온보딩 완료 후 사용자 정보 갱신
+			await fetchUserInfo();
 			navigate("/home");
 		}
 	};

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -29,7 +29,7 @@ export const Home = () => {
 
 	// 온보딩 미완료 시 온보딩 페이지로 리다이렉트
 	useEffect(() => {
-		if (userInfo?.result && userInfo.result.onboardingCompleted === false) {
+		if (userInfo?.result && userInfo.result.isOnboardingCompleted === false) {
 			navigate("/onboarding", { replace: true });
 		}
 	}, [userInfo, navigate]);

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,7 +1,7 @@
 import { closeView } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import { Asset, Border, Button, ProgressBar, Text } from "@toss/tds-mobile";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import homeBanner from "../../assets/HomeBanner.png";
 import { BottomNavigation } from "../../components/BottomNavigation";
@@ -26,6 +26,13 @@ export const Home = () => {
 
 	const { data: globalStats } = useGlobalStats();
 	const { data: result, error: ongoingSurveysError } = useOngoingSurveys();
+
+	// 온보딩 미완료 시 온보딩 페이지로 리다이렉트
+	useEffect(() => {
+		if (userInfo?.result && userInfo.result.onboardingCompleted === false) {
+			navigate("/onboarding", { replace: true });
+		}
+	}, [userInfo, navigate]);
 
 	const handleMySurvey = () => navigate("/mysurvey");
 	const handleMyPage = () => navigate("/mypage");

--- a/src/service/user/type.ts
+++ b/src/service/user/type.ts
@@ -6,7 +6,7 @@ export interface createUserResponse {
 		profileUrl: string;
 		coin: number;
 		promotionPoint: number;
-		onboardingCompleted: boolean;
+		isOnboardingCompleted: boolean;
 	};
 	success: boolean;
 }

--- a/src/service/user/type.ts
+++ b/src/service/user/type.ts
@@ -6,6 +6,7 @@ export interface createUserResponse {
 		profileUrl: string;
 		coin: number;
 		promotionPoint: number;
+		onboardingCompleted: boolean;
 	};
 	success: boolean;
 }

--- a/src/service/userInfo/types.ts
+++ b/src/service/userInfo/types.ts
@@ -6,4 +6,5 @@ export interface MemberInfo {
 	profileUrl: string;
 	coin: number;
 	promotionPoint: number;
+	onboardingCompleted: boolean;
 }

--- a/src/service/userInfo/types.ts
+++ b/src/service/userInfo/types.ts
@@ -6,5 +6,5 @@ export interface MemberInfo {
 	profileUrl: string;
 	coin: number;
 	promotionPoint: number;
-	onboardingCompleted: boolean;
+	isOnboardingCompleted: boolean;
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->
### 문제점
- 자동 로그인 시 온보딩 완료 여부를 확인하지 않아, 온보딩 미완료 사용자도 홈 화면으로 이동하는 문제
- 온보딩 완료 후 UserContext가 갱신되지 않아 재진입 시 온보딩이 다시 표시되는 문제

### 해결 방법
1. **타입 정의 업데이트**
   - `/v1/members` API 응답에 `isOnboardingCompleted` 필드가 추가되었고, 프론트엔드에 반영
   - `MemberInfo`, `createUserResponse` 타입에 `isOnboardingCompleted` 필드 추가
   - 기존 `onboardingCompleted` → `isOnboardingCompleted`로 변경

3. **자동 로그인 로직 개선** (`Intro.tsx`)
   - `getMemberInfo()` 응답의 `isOnboardingCompleted` 값을 확인하여 라우팅
   - `true` → `/home`, `false` → `/onboarding`

4. **온보딩 완료 후 상태 갱신** (`Onboarding.tsx`)
   - 온보딩 완료 시 `UserContext`의 `fetchUserInfo()` 호출하여 사용자 정보 갱신

5. **홈 화면 온보딩 체크 로직 업데이트** (`Home.tsx`)
   - `userInfo.result.isOnboardingCompleted` 필드명 변경에 맞춰 수정

## 🧪 테스트
- [x] 자동 로그인 시 온보딩 미완료 사용자는 온보딩 페이지로 이동
- [x] 자동 로그인 시 온보딩 완료 사용자는 홈 화면으로 이동
- [x] 온보딩 완료 후 재진입 시 홈 화면으로 정상 이동
- [x] 수동 로그인 시 온보딩 상태에 따른 라우팅 정상 동작

## 📋 관련 이슈
- 온보딩 완료 후에도 재진입 시 온보딩이 다시 표시되는 문제 해결
- `/v1/members` API 응답 스펙 변경에 따른 프론트엔드 타입 및 로직 업데이트


## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 온보딩 완료 상태 확인 추가
  * 미완료 사용자를 온보딩 페이지로 자동 리디렉션
  * 온보딩 완료 후 사용자 정보 자동 갱신

* **개선 사항**
  * 종료된 설문조사 필터링 로직 간소화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->