### PR TITLE
[OMF-79] 무료 설문 등록 기능 구현 및 유료/무료 설문 구분 UI 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import {
 	Onboarding,
 	PaymentLoading,
 	PaymentMain,
+	PaymentSuccessPage,
 	QuestionListPage,
 	QuestionOptionsPage,
 	QuestionTitleAndDescriptionEditPage,
@@ -231,6 +232,10 @@ export const App = () => {
 										<Route
 											path="/payment/loading"
 											element={<PaymentLoading />}
+										/>
+										<Route
+											path="/payment/success"
+											element={<PaymentSuccessPage />}
 										/>
 										<Route
 											path="/createForm/multipleChoice"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { UserProvider } from "./contexts/UserContext";
 import {
 	DatePage,
 	EstimatePage,
+	FreeRegistrationNotice,
 	Home,
 	Intro,
 	LocationSelectPage,
@@ -29,6 +30,7 @@ import {
 	NPSPage,
 	NumberPage,
 	Onboarding,
+	PaymentLoading,
 	PaymentMain,
 	QuestionListPage,
 	QuestionOptionsPage,
@@ -222,6 +224,14 @@ export const App = () => {
 											element={<EstimateNavigationPage />}
 										/>
 										<Route path="/payment/charge" element={<PaymentMain />} />
+										<Route
+											path="/payment/free-registration-notice"
+											element={<FreeRegistrationNotice />}
+										/>
+										<Route
+											path="/payment/loading"
+											element={<PaymentLoading />}
+										/>
 										<Route
 											path="/createForm/multipleChoice"
 											element={<MultipleChoicePage />}

--- a/src/components/surveyList/CustomSurveyList.tsx
+++ b/src/components/surveyList/CustomSurveyList.tsx
@@ -61,7 +61,9 @@ export const CustomSurveyList = ({
 									topProps={{ color: adaptive.green500 }}
 									middle={survey.title}
 									middleProps={{ color: adaptive.grey800, fontWeight: "bold" }}
-									bottom="3분이면 200원 획득"
+									bottom={
+										survey.isFree ? "보상이 없어요" : "3분이면 200원 획득"
+									}
 									bottomProps={{ color: adaptive.grey600 }}
 								/>
 							}

--- a/src/components/surveyList/SurveyList.tsx
+++ b/src/components/surveyList/SurveyList.tsx
@@ -58,7 +58,7 @@ export const SurveyList = ({ surveys }: SurveyListProps) => {
 								topProps={{ color: adaptive.green500 }}
 								middle={survey.title}
 								middleProps={{ color: adaptive.grey800, fontWeight: "bold" }}
-								bottom="3분이면 200원 획득"
+								bottom={survey.isFree ? "보상이 없어요" : "3분이면 200원 획득"}
 								bottomProps={{ color: adaptive.grey600 }}
 							/>
 						}

--- a/src/components/surveyList/UrgentSurveyList.tsx
+++ b/src/components/surveyList/UrgentSurveyList.tsx
@@ -111,7 +111,7 @@ export const UrgentSurveyList = ({
 								{survey.title}
 							</Text>
 							{survey.iconType === "image" && survey.remainingTimeText ? (
-								<div className="flex items-center gap-1 mb-3">
+								<div className="flex items-center gap-1 mb-2">
 									<Asset.Icon
 										frameShape={Asset.frameShape.CleanW16}
 										backgroundColor="transparent"
@@ -129,7 +129,28 @@ export const UrgentSurveyList = ({
 									</Text>
 								</div>
 							) : (
-								<div className="mb-3" />
+								<div className="mb-2" />
+							)}
+							{typeof survey.isFree === "boolean" && (
+								<div className="flex items-center gap-1 mb-3">
+									{!survey.isFree && (
+										<Asset.Icon
+											frameShape={Asset.frameShape.CleanW16}
+											backgroundColor="transparent"
+											name="icon-money-bag-point-mono"
+											color={adaptive.grey600}
+											aria-hidden={true}
+											ratio="1/1"
+										/>
+									)}
+									<Text
+										color={adaptive.grey800}
+										typography="t7"
+										fontWeight="semibold"
+									>
+										{survey.isFree ? "보상이 없어요" : "200원"}
+									</Text>
+								</div>
 							)}
 							<div className="flex-1" />
 							<span className="mt-auto inline-flex h-9 items-center justify-center rounded-xl px-4 text-sm font-semibold text-gray-700 bg-gray-300/40">

--- a/src/hooks/useSurveyNavigation.ts
+++ b/src/hooks/useSurveyNavigation.ts
@@ -15,6 +15,7 @@ interface UseSurveyNavigationState {
 	questions?: TransformedSurveyQuestion[];
 	currentQuestionIndex?: number;
 	answers?: Record<number, string>;
+	isFree?: boolean;
 }
 
 interface UseSurveyNavigationOptions {
@@ -117,7 +118,10 @@ export const useSurveyNavigation = ({
 				await completeSurvey(surveyId);
 				navigate("/survey/complete", {
 					replace: true,
-					state: { surveyId },
+					state: {
+						surveyId,
+						isFree: locationState?.isFree,
+					},
 				});
 				return;
 			}

--- a/src/hooks/useUserSurveys.ts
+++ b/src/hooks/useUserSurveys.ts
@@ -27,6 +27,7 @@ export const useUserSurveys = () => {
 				id: survey.surveyId,
 				title: survey.title,
 				description: survey.description,
+				isFree: survey.isFree,
 			}));
 
 		const activeStatuses = new Set(["ONGOING", "ACTIVE"]);
@@ -39,6 +40,7 @@ export const useUserSurveys = () => {
 				deadline: survey.deadLine ?? undefined,
 				progress: survey.currentCount ?? 0,
 				total: survey.dueCount ?? 0,
+				isFree: survey.isFree,
 			}));
 
 		const closed: ClosedSurvey[] = userSurveys
@@ -48,6 +50,7 @@ export const useUserSurveys = () => {
 				title: survey.title,
 				description: survey.description,
 				closedAt: survey.deadLine ?? undefined,
+				isFree: survey.isFree,
 			}));
 
 		return {

--- a/src/pages/QuestionForm/api/api.ts
+++ b/src/pages/QuestionForm/api/api.ts
@@ -3,6 +3,7 @@ import { api } from "../../../service/axios";
 import type {
 	CreateFormRequest,
 	CreateFormResponse,
+	CreateFreeFormRequest,
 	CreateScreeningsResponse,
 	CreateSurveyInterestsResponse,
 	CreateSurveyQuestionResponse,
@@ -70,6 +71,19 @@ export const createForm = async ({
 }: CreateFormRequest & { surveyId: number }): Promise<CreateFormResponse> => {
 	const { data } = await api.patch<CreateFormResponse, CreateFormRequest>(
 		`/v1/survey-form/surveys/${surveyId}`,
+		formPayload,
+	);
+	return data;
+};
+
+export const createFreeForm = async ({
+	surveyId,
+	...formPayload
+}: CreateFreeFormRequest & {
+	surveyId: number;
+}): Promise<CreateFormResponse> => {
+	const { data } = await api.patch<CreateFormResponse, CreateFreeFormRequest>(
+		`/v1/survey-form/surveys/${surveyId}/free`,
 		formPayload,
 	);
 	return data;

--- a/src/pages/QuestionForm/api/types.ts
+++ b/src/pages/QuestionForm/api/types.ts
@@ -152,6 +152,10 @@ export interface CreateFormRequest {
 	totalCoin: number;
 }
 
+export interface CreateFreeFormRequest {
+	deadline: string;
+}
+
 export interface SaveAsDraftResponse extends BaseResponse {
 	result: {
 		surveyId: number;

--- a/src/pages/QuestionForm/hooks/useSurveyMutation.ts
+++ b/src/pages/QuestionForm/hooks/useSurveyMutation.ts
@@ -1,8 +1,14 @@
 import { useMutation } from "@tanstack/react-query";
-import { createForm, createSurvey, patchSurvey } from "../api/api";
+import {
+	createForm,
+	createFreeForm,
+	createSurvey,
+	patchSurvey,
+} from "../api/api";
 import type {
 	CreateFormRequest,
 	CreateFormResponse,
+	CreateFreeFormRequest,
 	CreateSurveyResponse,
 	PatchSurveyRequest,
 	PatchSurveyResponse,
@@ -33,6 +39,20 @@ export const useCreateForm = () => {
 	>({
 		mutationFn: ({ surveyId, ...formPayload }) =>
 			createForm({ surveyId, ...formPayload }),
+	});
+};
+
+/**
+ * 무료 폼 생성 mutation
+ */
+export const useCreateFreeForm = () => {
+	return useMutation<
+		CreateFormResponse,
+		Error,
+		CreateFreeFormRequest & { surveyId: number }
+	>({
+		mutationFn: ({ surveyId, ...formPayload }) =>
+			createFreeForm({ surveyId, ...formPayload }),
 	});
 };
 

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -104,7 +104,6 @@ export const Survey = () => {
 					const status = error.response.status;
 
 					if (status === 401) {
-						// 인증 실패 - 로그인 페이지로 이동
 						setErrorDialog({
 							open: true,
 							title: "로그인이 필요합니다",
@@ -198,9 +197,10 @@ export const Survey = () => {
 	};
 
 	const handleErrorDialogConfirm = () => {
-		setErrorDialog({ open: false, title: "" });
-		if (errorDialog.redirectTo) {
-			navigate(errorDialog.redirectTo, { replace: true });
+		const redirectTo = errorDialog.redirectTo;
+		setErrorDialog({ open: false, title: "", redirectTo: undefined });
+		if (redirectTo) {
+			navigate(redirectTo, { replace: true });
 		}
 	};
 

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -255,7 +255,9 @@ export const Survey = () => {
 								typography="t5"
 								fontWeight="semibold"
 							>
-								참여 보상 : 200원
+								{surveyInfo?.isFree
+									? "참여보상이 없는 설문이에요"
+									: "참여 보상 : 200원"}
 							</Text>
 							<div className="h-2" />
 							<Text

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -39,6 +39,7 @@ export const Survey = () => {
 		topicId?: InterestId;
 		remainingTimeText?: string;
 		isClosed?: boolean;
+		isFree?: boolean;
 	} | null>(null);
 
 	// 에러 다이얼로그 상태
@@ -88,6 +89,7 @@ export const Survey = () => {
 					topicId: (result.interests?.[0] ?? "CAREER") as InterestId,
 					remainingTimeText,
 					isClosed,
+					isFree: result.isFree,
 				});
 			} catch (err) {
 				console.log("err", err);
@@ -190,6 +192,7 @@ export const Survey = () => {
 				questions: sortedQuestions,
 				currentQuestionIndex: 0,
 				answers: {},
+				isFree: surveyInfo?.isFree,
 			},
 		});
 	};

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -133,15 +133,33 @@ export const Home = () => {
 			/>
 			<div className="flex flex-col w-full min-h-screen">
 				<div className="px-4 py-6">
-					<Text color={adaptive.grey800} typography="t5" fontWeight="bold">
-						지금{" "}
-					</Text>
-					<Text color={adaptive.green400} typography="t5" fontWeight="bold">
-						3,200명
-					</Text>
-					<Text color={adaptive.grey800} typography="t5" fontWeight="bold">
-						이 설문을 보고 있어요 👀
-					</Text>
+					<div className="w-full h-fit bg-[var(--adaptiveCardBgGrey)] rounded-[24px] p-4 backdrop-blur-none">
+						<Asset.Image
+							frameShape={Asset.frameShape.CleanW24}
+							backgroundColor="transparent"
+							src="https://static.toss.im/2d-emojis/png/4x/u1F440.png"
+							aria-hidden={true}
+							style={{ aspectRatio: "1/1" }}
+						/>
+						<Text color={adaptive.grey800} typography="t6" fontWeight="medium">
+							현재{" "}
+						</Text>
+						<Text
+							color={adaptive.green400}
+							typography="t6"
+							fontWeight="semibold"
+						>
+							3,400명{" "}
+						</Text>
+						<Text
+							display="block"
+							color={adaptive.grey800}
+							typography="t6"
+							fontWeight="medium"
+						>
+							이 설문을 보고 있어요
+						</Text>
+					</div>
 				</div>
 				<div className="relative mx-4 mb-6 rounded-4xl overflow-hidden shrink-0 h-[337px]">
 					<div className="absolute inset-0 home-banner-gradient" />

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -1,7 +1,7 @@
 import { closeView } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import { Asset, Border, Button, ProgressBar, Text } from "@toss/tds-mobile";
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import homeBanner from "../../assets/HomeBanner.png";
 import { BottomNavigation } from "../../components/BottomNavigation";
@@ -26,6 +26,11 @@ export const Home = () => {
 
 	const { data: globalStats } = useGlobalStats();
 	const { data: result, error: ongoingSurveysError } = useOngoingSurveys();
+	// 3천대 랜덤 숫자 생성 (3000~3999)
+	const [randomCount] = useState(() => {
+		const random = Math.floor(Math.random() * 1000) + 3000;
+		return random.toLocaleString();
+	});
 
 	// 온보딩 미완료 시 온보딩 페이지로 리다이렉트
 	useEffect(() => {
@@ -132,8 +137,8 @@ export const Home = () => {
 				onConfirm={handleConfirmDialogConfirm}
 			/>
 			<div className="flex flex-col w-full min-h-screen">
-				<div className="px-4 py-6">
-					<div className="w-full h-fit bg-[var(--adaptiveCardBgGrey)] rounded-[24px] p-4 backdrop-blur-none">
+				<div className="p-4">
+					<div className="w-full h-fit rounded-[24px] p-4 backdrop-blur-none flex items-center gap-2 bg-gray-100">
 						<Asset.Image
 							frameShape={Asset.frameShape.CleanW24}
 							backgroundColor="transparent"
@@ -142,21 +147,16 @@ export const Home = () => {
 							style={{ aspectRatio: "1/1" }}
 						/>
 						<Text color={adaptive.grey800} typography="t6" fontWeight="medium">
-							현재{" "}
+							현재
 						</Text>
 						<Text
 							color={adaptive.green400}
 							typography="t6"
 							fontWeight="semibold"
 						>
-							3,400명{" "}
+							{randomCount}명
 						</Text>
-						<Text
-							display="block"
-							color={adaptive.grey800}
-							typography="t6"
-							fontWeight="medium"
-						>
+						<Text color={adaptive.grey800} typography="t6" fontWeight="medium">
 							이 설문을 보고 있어요
 						</Text>
 					</div>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -26,9 +26,9 @@ export const Home = () => {
 
 	const { data: globalStats } = useGlobalStats();
 	const { data: result, error: ongoingSurveysError } = useOngoingSurveys();
-	// 3천대 랜덤 숫자 생성 (3000~3999)
+
 	const [randomCount] = useState(() => {
-		const random = Math.floor(Math.random() * 1000) + 3000;
+		const random = Math.floor(Math.random() * 100) + 1;
 		return random.toLocaleString();
 	});
 

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -77,6 +77,7 @@ export const Home = () => {
 				description: survey.description,
 				remainingTimeText: remainingTime,
 				isClosed: remainingTime === "마감됨",
+				isFree: survey.isFree,
 			};
 		};
 

--- a/src/pages/home/hooks/useOngoingSurveys.ts
+++ b/src/pages/home/hooks/useOngoingSurveys.ts
@@ -1,10 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { getOngoingSurveys } from "../../../service/surveyList";
 
-export const useOngoingSurveys = () => {
+export const useOngoingSurveys = (enabled: boolean = true) => {
 	return useQuery({
 		queryKey: ["ongoingSurveys"],
 		queryFn: () => getOngoingSurveys(),
 		refetchOnMount: "always",
+		enabled,
 	});
 };

--- a/src/pages/mysurvey/components/SurveyCard.tsx
+++ b/src/pages/mysurvey/components/SurveyCard.tsx
@@ -87,9 +87,20 @@ export const SurveyCard = ({ survey, type, onClick }: SurveyCardProps) => {
 	return (
 		<div className="bg-gray-50 rounded-xl p-4 relative" {...cardProps}>
 			<div className="flex items-start justify-between mb-2">
-				<Badge variant="weak" color={config.color} size="small">
-					{config.label}
-				</Badge>
+				<div className="flex items-center gap-2">
+					<Badge variant="weak" color={config.color} size="small">
+						{config.label}
+					</Badge>
+					{type !== "draft" && typeof survey.isFree === "boolean" && (
+						<Badge
+							variant="weak"
+							color={survey.isFree ? "elephant" : "yellow"}
+							size="small"
+						>
+							{survey.isFree ? "무료" : "유료"}
+						</Badge>
+					)}
+				</div>
 				<button
 					type="button"
 					className="cursor-pointer"

--- a/src/pages/mysurvey/components/types.ts
+++ b/src/pages/mysurvey/components/types.ts
@@ -3,6 +3,7 @@ interface BaseSurvey {
 	title: string;
 	description?: string;
 	memberId?: number;
+	isFree?: boolean;
 }
 
 export interface DraftSurvey extends BaseSurvey {}

--- a/src/pages/payment/EstimatePage.tsx
+++ b/src/pages/payment/EstimatePage.tsx
@@ -3,6 +3,7 @@ import { adaptive } from "@toss/tds-colors";
 import {
 	Asset,
 	ConfirmDialog,
+	CTAButton,
 	FixedBottomCTA,
 	TextField,
 } from "@toss/tds-mobile";
@@ -178,6 +179,10 @@ export const EstimatePage = () => {
 		handleEstimateChange({ ...estimate, ages });
 	};
 
+	const handleFreeRegistration = () => {
+		navigate("/payment/free-registration-notice");
+	};
+
 	useBackEventListener(() => setSurveyStep(3));
 
 	return (
@@ -302,15 +307,31 @@ export const EstimatePage = () => {
 				value={estimate.date ?? new Date()}
 				onChange={handleDateBottomSheetConfirm}
 			/>
-			<FixedBottomCTA
-				loading={false}
-				onClick={handleConfirmDialogOpen}
-				style={
-					{ "--button-background-color": "#15c67f" } as React.CSSProperties
+			<FixedBottomCTA.Double
+				leftButton={
+					<CTAButton
+						color="dark"
+						variant="weak"
+						display="block"
+						onClick={handleFreeRegistration}
+					>
+						무료로 등록하기
+					</CTAButton>
 				}
-			>
-				{formatPriceAsCoin(totalPrice)} 결제하기
-			</FixedBottomCTA>
+				rightButton={
+					<CTAButton
+						display="block"
+						onClick={handleConfirmDialogOpen}
+						style={
+							{
+								"--button-background-color": "#15c67f",
+							} as React.CSSProperties
+						}
+					>
+						{formatPriceAsCoin(totalPrice)} 결제하기
+					</CTAButton>
+				}
+			/>
 		</>
 	);
 };

--- a/src/pages/payment/FreeRegistrationNotice.tsx
+++ b/src/pages/payment/FreeRegistrationNotice.tsx
@@ -1,0 +1,176 @@
+import { adaptive } from "@toss/tds-colors";
+import {
+	Asset,
+	BottomSheet,
+	Button,
+	FixedBottomCTA,
+	Post,
+	StepperRow,
+	Top,
+} from "@toss/tds-mobile";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useBackEventListener } from "../../hooks/useBackEventListener";
+
+export const FreeRegistrationNotice = () => {
+	const navigate = useNavigate();
+	const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+	useBackEventListener(() => {
+		navigate(-1);
+	});
+
+	const handleFreeRegistration = () => {
+		setIsBottomSheetOpen(true);
+	};
+
+	const handleCloseBottomSheet = () => {
+		setIsBottomSheetOpen(false);
+	};
+
+	const handleConfirm = () => {
+		// TODO: 무료 등록 로직 구현
+		setIsBottomSheetOpen(false);
+		console.log("무료 등록 확인");
+	};
+
+	return (
+		<>
+			<Top
+				title={
+					<Top.TitleParagraph size={22} color={adaptive.grey900}>
+						이 혜택, 정말 포기하실 건가요?
+					</Top.TitleParagraph>
+				}
+				subtitleBottom={
+					<Top.SubtitleParagraph>
+						유료 설문은 응답의 질과 활용도가 달라요.
+					</Top.SubtitleParagraph>
+				}
+				upper={
+					<Top.UpperAssetContent
+						content={
+							<Asset.Lottie
+								frameShape={Asset.frameShape.CleanW60}
+								src="https://static.toss.im/lotties-common/alarm-spot.json"
+								loop={false}
+								aria-hidden={true}
+							/>
+						}
+					/>
+				}
+			/>
+			<div className="px-4">
+				<StepperRow
+					left={
+						<StepperRow.AssetFrame
+							shape={Asset.frameShape.CleanW32}
+							content={
+								<Asset.ContentImage
+									src="https://static.toss.im/2d-emojis/png/4x/u1F3AF.png"
+									aria-hidden={true}
+								/>
+							}
+						/>
+					}
+					center={
+						<StepperRow.Texts
+							type="A"
+							title="세그먼트 설정"
+							description="연령,성별,거주지,스크리닝 설정으로 원하는 타겟에게만 정확히 질문하세요."
+						/>
+					}
+				/>
+				<StepperRow
+					left={
+						<StepperRow.AssetFrame
+							shape={Asset.frameShape.CleanW32}
+							content={
+								<Asset.ContentImage
+									src="https://static.toss.im/2d-emojis/png/4x/u26A1.png"
+									aria-hidden={true}
+								/>
+							}
+						/>
+					}
+					center={
+						<StepperRow.Texts
+							type="A"
+							title="높은 응답 완료율"
+							description="100명 응답, 약 1시간 내 완료 강력한 리워드  온서베이 패널 조합으로 설문 응답 완료까지 책임지고 지원합니다."
+						/>
+					}
+				/>
+				<StepperRow
+					left={
+						<StepperRow.AssetFrame
+							shape={Asset.frameShape.CleanW32}
+							content={
+								<Asset.ContentImage
+									src="https://static.toss.im/2d-emojis/png/4x/u1F4CA.png"
+									aria-hidden={true}
+								/>
+							}
+						/>
+					}
+					center={
+						<StepperRow.Texts
+							type="A"
+							title="연령대·성별·지역별 결과 비교"
+							description="선택한 세그먼트를 조합해, 의미 있는 인사이트만 확인하세요."
+						/>
+					}
+					hideLine={true}
+				/>
+			</div>
+			<FixedBottomCTA
+				loading={false}
+				onClick={handleFreeRegistration}
+				style={
+					{ "--button-background-color": "#15c67f" } as React.CSSProperties
+				}
+			>
+				무료로 등록하기
+			</FixedBottomCTA>
+			<BottomSheet
+				header={
+					<BottomSheet.Header>
+						설문을 무료로 등록하면 이런 제약이 생겨요.{" "}
+					</BottomSheet.Header>
+				}
+				open={isBottomSheetOpen}
+				onClose={handleCloseBottomSheet}
+				cta={
+					<BottomSheet.DoubleCTA
+						leftButton={
+							<Button
+								color="dark"
+								variant="weak"
+								onClick={handleCloseBottomSheet}
+							>
+								닫기
+							</Button>
+						}
+						rightButton={<Button onClick={handleConfirm}>확인했어요</Button>}
+					/>
+				}
+			>
+				<Post.Ul>
+					<Post.Li>
+						타겟·스크리닝 설정 불가 : 연령·성별·거주지 설정 및 스크리닝 질문이
+						응답에 반영되지 않아요.
+					</Post.Li>
+					<Post.Li>
+						응답 수 제한 및 설문 완료 미보장 : 응답자는 최대 100명으로 제한되며,
+						추가 수집이 불가능해요.온서베이는 무료 설문의 응답 완료를 보장하지
+						않아요.
+					</Post.Li>
+					<Post.Li>
+						리워드 및 분석 기능 미제공 : 응답자 리워드가 제공되지 않으며,
+						세그먼트 분석 기능을 사용할 수 없어요.
+					</Post.Li>
+				</Post.Ul>
+			</BottomSheet>
+		</>
+	);
+};

--- a/src/pages/payment/FreeRegistrationNotice.tsx
+++ b/src/pages/payment/FreeRegistrationNotice.tsx
@@ -78,8 +78,8 @@ export const FreeRegistrationNotice = () => {
 			queryClient.invalidateQueries({ queryKey: ["userSurveys"] });
 			queryClient.invalidateQueries({ queryKey: ["memberInfo"] });
 
-			// 성공 페이지로 이동
-			navigate("/payment/success");
+			// PaymentLoading으로 이동 (무료 설문임을 표시)
+			navigate("/payment/loading", { state: { isFree: true } });
 		} catch (error) {
 			console.error("무료 설문 등록 실패:", error);
 			// 에러 처리 (토스트 메시지 등)

--- a/src/pages/payment/PaymentLoading.tsx
+++ b/src/pages/payment/PaymentLoading.tsx
@@ -1,20 +1,29 @@
 import { adaptive } from "@toss/tds-colors";
 import { Asset, Top } from "@toss/tds-mobile";
 import { useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { useMultiStep } from "../../contexts/MultiStepContext";
 import { useBackEventListener } from "../../hooks/useBackEventListener";
 
 export const PaymentLoading = () => {
 	const location = useLocation();
+	const navigate = useNavigate();
 	const isChargeFlow = location.pathname === "/payment/charge";
+	const locationState = location.state as { isFree?: boolean } | undefined;
+	const isFree = locationState?.isFree ?? false;
 	const { goNextPayment } = useMultiStep();
 
 	useEffect(() => {
 		setTimeout(() => {
-			goNextPayment();
+			if (isFree) {
+				// 무료 설문인 경우 성공 페이지로 직접 이동
+				navigate("/payment/success");
+			} else {
+				// 유료 설문인 경우 기존 플로우 유지
+				goNextPayment();
+			}
 		}, 3000);
-	}, [goNextPayment]);
+	}, [goNextPayment, isFree, navigate]);
 
 	useBackEventListener(() => {});
 
@@ -25,7 +34,9 @@ export const PaymentLoading = () => {
 					<Top.TitleParagraph size={22} color={adaptive.grey900}>
 						{isChargeFlow
 							? "코인을 충전하고 있어요"
-							: "보유 코인으로\n설문을 등록하고 있어요"}
+							: isFree
+								? "소중한 설문을 잘 등록하고 있어요"
+								: "보유 코인으로\n설문을 등록하고 있어요"}
 					</Top.TitleParagraph>
 				}
 				subtitleBottom={

--- a/src/pages/payment/index.ts
+++ b/src/pages/payment/index.ts
@@ -1,4 +1,5 @@
 export * from "./EstimatePage";
+export * from "./FreeRegistrationNotice";
 export * from "./LocationSelectPage";
 export * from "./PaymentConfirmationPage";
 export * from "./PaymentLoading";

--- a/src/pages/survey/Complete.tsx
+++ b/src/pages/survey/Complete.tsx
@@ -16,8 +16,12 @@ export const SurveyComplete = () => {
 	const { state, setSurveyId } = useSurvey();
 	const [userName, setUserName] = useState<string>("");
 
-	// location state에서 surveyId 가져오기
-	const surveyIdFromState = (location.state as { surveyId?: number })?.surveyId;
+	// location state에서 surveyId와 isFree 가져오기
+	const locationState = location.state as
+		| { surveyId?: number; isFree?: boolean }
+		| undefined;
+	const surveyIdFromState = locationState?.surveyId;
+	const isFreeFromState = locationState?.isFree;
 
 	// surveyId를 context에 설정
 	useEffect(() => {
@@ -26,7 +30,7 @@ export const SurveyComplete = () => {
 		}
 	}, [surveyIdFromState, state.surveyId, setSurveyId]);
 
-	// 사용자 정보 가져오기 및 토스포인트 지급
+	// 사용자 정보 가져오기 및 토스포인트 지급 (무료 설문이 아닌 경우만)
 	useEffect(() => {
 		if (isUserInfoLoading) return;
 		if (!userInfo) return;
@@ -36,6 +40,12 @@ export const SurveyComplete = () => {
 				setUserName(userInfo?.result.name);
 				const surveyId = state.surveyId || surveyIdFromState;
 				if (!surveyId) return;
+
+				// 무료 설문인 경우 프로모션 지급하지 않음 (이미 가져온 isFree 정보 사용)
+				if (isFreeFromState) {
+					console.log("무료 설문이므로 프로모션 지급을 건너뜁니다.");
+					return;
+				}
 
 				// 재시도 로직
 				const MAX_RETRIES = 5;
@@ -73,7 +83,13 @@ export const SurveyComplete = () => {
 		};
 
 		void fetchUserAndIssuePromotion();
-	}, [state.surveyId, surveyIdFromState, userInfo, isUserInfoLoading]);
+	}, [
+		state.surveyId,
+		surveyIdFromState,
+		userInfo,
+		isUserInfoLoading,
+		isFreeFromState,
+	]);
 
 	useBackEventListener(() => {
 		navigate("/home", { replace: true });

--- a/src/pages/survey/Ineligible.tsx
+++ b/src/pages/survey/Ineligible.tsx
@@ -45,6 +45,7 @@ export const Ineligible = () => {
 						description: survey.description,
 						remainingTimeText: remainingTime,
 						isClosed: remainingTime === "마감됨",
+						isFree: survey.isFree,
 					};
 				};
 

--- a/src/pages/surveyList/SurveyList.tsx
+++ b/src/pages/surveyList/SurveyList.tsx
@@ -88,6 +88,7 @@ export const SurveyListPage = () => {
 				iconSrc,
 				iconName: topic?.icon.type === "icon" ? topic.icon.name : undefined,
 				description: survey.description,
+				isFree: survey.isFree,
 			};
 		};
 

--- a/src/service/mysurvey/api.ts
+++ b/src/service/mysurvey/api.ts
@@ -68,6 +68,7 @@ export interface UserSurvey {
 	createdAt: string;
 	updatedAt: string;
 	memberId?: number;
+	isFree?: boolean;
 }
 
 export interface UserSurveyResponse {

--- a/src/service/mysurvey/types.ts
+++ b/src/service/mysurvey/types.ts
@@ -33,6 +33,7 @@ export interface SurveyQuestionInfo {
 
 export interface SurveyDetailResult {
 	info: SurveyQuestionInfo[];
+	isFree?: boolean;
 }
 
 export interface SurveyDetailResponse extends BaseResponse {

--- a/src/service/surveyList/types.ts
+++ b/src/service/surveyList/types.ts
@@ -14,6 +14,7 @@ export interface OngoingSurveySummary {
 	interest?: InterestId;
 	interests?: InterestId[];
 	deadline?: string;
+	isFree?: boolean;
 }
 
 export interface OngoingSurveyResult {

--- a/src/service/surveyParticipation/api.ts
+++ b/src/service/surveyParticipation/api.ts
@@ -24,6 +24,7 @@ export const getSurveyParticipation = async (
 	description: string;
 	interests: string[];
 	deadline: string;
+	isFree?: boolean;
 }> => {
 	const result = await apiCall<SurveyParticipationInfo>({
 		method: "GET",
@@ -70,6 +71,7 @@ export const getSurveyParticipation = async (
 		description: result.description,
 		interests: result.interests,
 		deadline: result.deadline,
+		isFree: result.isFree,
 	};
 };
 

--- a/src/service/surveyParticipation/types.ts
+++ b/src/service/surveyParticipation/types.ts
@@ -86,6 +86,7 @@ export interface SurveyParticipationInfo {
 	interests: string[];
 	deadline: string;
 	info: SurveyParticipationQuestion[];
+	isFree?: boolean;
 }
 
 // 프론트엔드에서 사용하는 변환된 문항 타입

--- a/src/types/surveyList.ts
+++ b/src/types/surveyList.ts
@@ -10,4 +10,5 @@ export interface SurveyListItem {
 	description?: string;
 	remainingTimeText?: string;
 	isClosed?: boolean;
+	isFree?: boolean;
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

### 1. 무료 설문 등록 기능
- 무료 설문 등록 API 구현 (`/v1/survey-form/surveys/{surveyId}/free`)
- 무료 설문 등록 플로우 구현 (EstimatePage → FreeRegistrationNotice → PaymentLoading)
- 무료 설문 등록 시 기본값 자동 설정 (응답자 수 100명, 전체 세그먼트, 스크리닝 없음)
- 무료 설문 등록 시 프로모션 지급 제외

### 2. 유료/무료 설문 구분 UI
- **내 설문 탭**: 수집중/마감 설문에 "무료"/"유료" 뱃지 추가
- **맞춤 설문 리스트**: 무료 설문 시 "보상이 없어요" 텍스트 표시
- **마감임박 설문 리스트**: 무료 설문 시 "보상이 없어요", 유료 설문 시 "200원" 표시
- **설문 참여 페이지**: 무료 설문 시 "참여보상이 없는 설문이에요" 텍스트 표시

### 3. 기타 개선사항
- 설문 참여 페이지 401 에러 발생 시 로그인 다이얼로그 표시 및 리다이렉트 처리 개선

## 🔧 기술적 변경사항

- `isFree` 필드를 설문 관련 타입에 추가 (`SurveyListItem`, `UserSurvey`, `SurveyParticipationInfo` 등)
- 무료 설문 등록 API 분리 (`createFreeForm`)
- 설문 참여 완료 페이지에서 무료 설문 여부를 location.state로 전달하여 불필요한 API 호출 제거


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: https://onsurvey.atlassian.net/browse/OMF-79


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 흐름에 무료 등록 경로(안내 → 진행 → 성공) 추가
  * 결제 페이지에 "무료로 등록하기" CTA 및 이중 CTA 레이아웃 도입
  * 설문 리스트/상세에 무료 여부 반영—보상 문구가 "보상이 없어요"로 표시되는 경우 추가
  * 마이페이지와 설문 카드에 무료/유료 배지 표시
  * 홈에 실시간 스타일의 참가자 카운트 배너 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->