### PR TITLE
[OMF-98] 로그인을 안 하고 설문 페이지 접속시 로그인 요청 모달 표시

### DIFF
--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -9,7 +9,7 @@ import {
 	Top,
 } from "@toss/tds-mobile";
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { ExitConfirmDialog } from "../components/ExitConfirmDialog";
 import { type RegionData, regions } from "../constants/regions";
 import { type TopicData, topics } from "../constants/topics";
@@ -17,6 +17,7 @@ import { useUserInfo } from "../contexts/UserContext";
 import { useModal } from "../hooks/UseToggle";
 import { useBackEventListener } from "../hooks/useBackEventListener";
 import { OnboardingApi } from "../service/onboading";
+import type { LocationStateWithReturnTo } from "../types/navigation";
 import { pushGtmEvent } from "../utils/gtm";
 
 const OnboardingStep1 = ({
@@ -109,7 +110,9 @@ const OnboardingStep2 = ({
 	handleTopicToggle: (topic: TopicData) => void;
 }) => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { fetchUserInfo } = useUserInfo();
+	const returnTo = (location.state as LocationStateWithReturnTo)?.returnTo;
 
 	const handleSubmit = async () => {
 		if (!selectedRegion) return;
@@ -132,7 +135,15 @@ const OnboardingStep2 = ({
 				signup: "로그인 유무",
 			});
 
-			navigate("/home");
+			// 원래 페이지로 돌아가거나 홈으로 이동
+			if (returnTo) {
+				navigate(returnTo.path, {
+					replace: true,
+					state: returnTo.state,
+				});
+			} else {
+				navigate("/home", { replace: true });
+			}
 		}
 	};
 

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -12,6 +12,7 @@ import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { type InterestId, topics } from "../constants/topics";
 import type { TransformedSurveyQuestion } from "../service/surveyParticipation";
 import { getSurveyParticipation } from "../service/surveyParticipation";
+import type { ReturnTo } from "../types/navigation";
 import type { SurveyListItem } from "../types/surveyList";
 import { formatRemainingTime } from "../utils/FormatDate";
 import { pushGtmEvent } from "../utils/gtm";
@@ -51,6 +52,7 @@ export const Survey = () => {
 		title: string;
 		description?: string;
 		redirectTo?: string;
+		returnTo?: ReturnTo;
 	}>({
 		open: false,
 		title: "",
@@ -137,6 +139,17 @@ export const Survey = () => {
 						title: "로그인이 필요합니다",
 						description: "로그인 후 이용해주세요",
 						redirectTo: "/",
+						returnTo: surveyId
+							? {
+									path: "/survey",
+									state: {
+										surveyId,
+										survey: surveyFromState,
+										source: locationState?.source ?? "main",
+										quiz_id: locationState?.quiz_id,
+									},
+								}
+							: undefined,
 					});
 					return;
 				}
@@ -166,7 +179,12 @@ export const Survey = () => {
 		return () => {
 			isMounted = false;
 		};
-	}, [surveyId]);
+	}, [
+		surveyId,
+		surveyFromState,
+		locationState?.source,
+		locationState?.quiz_id,
+	]);
 
 	const sortedQuestions = useMemo(
 		() =>
@@ -231,7 +249,12 @@ export const Survey = () => {
 	const handleErrorDialogConfirm = () => {
 		setErrorDialog({ open: false, title: "" });
 		if (errorDialog.redirectTo) {
-			navigate(errorDialog.redirectTo, { replace: true });
+			navigate(errorDialog.redirectTo, {
+				replace: true,
+				state: errorDialog.returnTo
+					? { returnTo: errorDialog.returnTo }
+					: undefined,
+			});
 		}
 	};
 

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -1,0 +1,18 @@
+/**
+ * 네비게이션 관련 타입 정의
+ */
+
+/**
+ * 리다이렉트 후 돌아올 페이지 정보
+ */
+export interface ReturnTo {
+	path: string;
+	state?: Record<string, unknown>;
+}
+
+/**
+ * location.state에 returnTo 정보를 포함하는 타입
+ */
+export interface LocationStateWithReturnTo {
+	returnTo?: ReturnTo;
+}


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 로그인을 안 하고 설문 페이지 접속시 로그인 요청 모달 표시

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->

JIRA링크: https://onsurvey.atlassian.net/browse/OMF-98

## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  
## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->

https://github.com/user-attachments/assets/98508345-25a9-4c29-83f1-e53d2bf4897b





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 로그인 후 원래 목적지로 되돌아가는 "returnTo" 이동 흐름을 도입했습니다 (온보딩·소개·설문 전반에 적용).

* **버그 수정**
  * 토큰 기반 인증 및 네트워크 오류 처리 개선: 세션 만료나 네트워크 문제 시 로그인 안내를 표시하고 적절히 리다이렉트합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->