### PR TITLE
[OMF-104] 문항 생성 중 뒤로가기 버튼 누르면 문항 생성이 안 되게 변경

### DIFF
--- a/src/pages/QuestionForm/DatePage.tsx
+++ b/src/pages/QuestionForm/DatePage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	FixedBottomCTA,
@@ -7,16 +6,16 @@ import {
 	Top,
 	WheelDatePicker,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const DatePage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -36,18 +35,7 @@ export const DatePage = () => {
 
 	const date = question?.date;
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const handleDateChange = (newDate: Date) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/DatePage.tsx
+++ b/src/pages/QuestionForm/DatePage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	FixedBottomCTA,
@@ -6,6 +7,7 @@ import {
 	Top,
 	WheelDatePicker,
 } from "@toss/tds-mobile";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
@@ -14,7 +16,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const DatePage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -33,6 +35,19 @@ export const DatePage = () => {
 	} = useQuestionByType("date");
 
 	const date = question?.date;
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const handleDateChange = (newDate: Date) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/LongAnswerPage.tsx
+++ b/src/pages/QuestionForm/LongAnswerPage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -7,6 +8,7 @@ import {
 	TextArea,
 	Top,
 } from "@toss/tds-mobile";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
@@ -15,7 +17,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const LongAnswerPage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -32,6 +34,19 @@ export const LongAnswerPage = () => {
 		title,
 		description,
 	} = useQuestionByType("longAnswer");
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/LongAnswerPage.tsx
+++ b/src/pages/QuestionForm/LongAnswerPage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -8,16 +7,16 @@ import {
 	TextArea,
 	Top,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const LongAnswerPage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -35,18 +34,7 @@ export const LongAnswerPage = () => {
 		description,
 	} = useQuestionByType("longAnswer");
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/NPSPage.tsx
+++ b/src/pages/QuestionForm/NPSPage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	FixedBottomCTA,
@@ -7,7 +8,7 @@ import {
 	Text,
 	Top,
 } from "@toss/tds-mobile";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
@@ -16,7 +17,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const NPSPage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -35,6 +36,19 @@ export const NPSPage = () => {
 		title,
 		description,
 	} = useQuestionByType("nps");
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/NPSPage.tsx
+++ b/src/pages/QuestionForm/NPSPage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	FixedBottomCTA,
@@ -8,16 +7,17 @@ import {
 	Text,
 	Top,
 } from "@toss/tds-mobile";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const NPSPage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -37,18 +37,7 @@ export const NPSPage = () => {
 		description,
 	} = useQuestionByType("nps");
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/NumberPage.tsx
+++ b/src/pages/QuestionForm/NumberPage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -8,16 +7,16 @@ import {
 	TextField,
 	Top,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const NumberPage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -35,18 +34,7 @@ export const NumberPage = () => {
 		description,
 	} = useQuestionByType("number");
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/NumberPage.tsx
+++ b/src/pages/QuestionForm/NumberPage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -7,6 +8,7 @@ import {
 	TextField,
 	Top,
 } from "@toss/tds-mobile";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
@@ -15,7 +17,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const NumberPage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -32,6 +34,19 @@ export const NumberPage = () => {
 		title,
 		description,
 	} = useQuestionByType("number");
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/RatingPage.tsx
+++ b/src/pages/QuestionForm/RatingPage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Asset,
@@ -8,6 +9,7 @@ import {
 	Text,
 	Top,
 } from "@toss/tds-mobile";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { useModal } from "../../hooks/UseToggle";
@@ -18,7 +20,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const RatingPage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -39,6 +41,19 @@ export const RatingPage = () => {
 	const minValue = question?.minValue ?? "내용 입력하기";
 	const maxValue = question?.maxValue ?? "내용 입력하기";
 	const ratingCount = question?.rate ?? 10;
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const {
 		isOpen: isMinValueEditOpen,

--- a/src/pages/QuestionForm/RatingPage.tsx
+++ b/src/pages/QuestionForm/RatingPage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Asset,
@@ -9,18 +8,18 @@ import {
 	Text,
 	Top,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { useModal } from "../../hooks/UseToggle";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
 import { RatingLabelEditBottomSheet } from "./components/bottomSheet/RatingLabelEditBottomSheete";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const RatingPage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -42,18 +41,7 @@ export const RatingPage = () => {
 	const maxValue = question?.maxValue ?? "내용 입력하기";
 	const ratingCount = question?.rate ?? 10;
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const {
 		isOpen: isMinValueEditOpen,

--- a/src/pages/QuestionForm/ShortAnswerPage.tsx
+++ b/src/pages/QuestionForm/ShortAnswerPage.tsx
@@ -1,3 +1,4 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -7,6 +8,7 @@ import {
 	TextArea,
 	Top,
 } from "@toss/tds-mobile";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
@@ -15,7 +17,7 @@ import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const ShortAnswerPage = () => {
-	const { state, updateQuestion } = useSurvey();
+	const { state, updateQuestion, deleteQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -32,6 +34,19 @@ export const ShortAnswerPage = () => {
 		title,
 		description,
 	} = useQuestionByType("shortAnswer");
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/ShortAnswerPage.tsx
+++ b/src/pages/QuestionForm/ShortAnswerPage.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Border,
@@ -8,16 +7,16 @@ import {
 	TextArea,
 	Top,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { useSurvey } from "../../contexts/SurveyContext";
 import { pushGtmEvent } from "../../utils/gtm";
 import { formatQuestionNumber } from "../../utils/questionFactory";
+import { useQuestionBackHandler } from "./hooks/useQuestionBackHandler";
 import { useQuestionByType } from "./hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "./hooks/useQuestionMutations";
 
 export const ShortAnswerPage = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 	const location = useLocation();
 	const navigate = useNavigate();
@@ -35,18 +34,7 @@ export const ShortAnswerPage = () => {
 		description,
 	} = useQuestionByType("shortAnswer");
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (!questionIdFromUrl && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const handleRequiredChange = (checked: boolean) => {
 		if (questionId) {

--- a/src/pages/QuestionForm/hooks/useQuestionBackHandler.ts
+++ b/src/pages/QuestionForm/hooks/useQuestionBackHandler.ts
@@ -1,0 +1,35 @@
+import { graniteEvent } from "@apps-in-toss/web-framework";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useSurvey } from "../../../contexts/SurveyContext";
+
+interface UseQuestionBackHandlerOptions {
+	questionId: string | undefined;
+	questionIdFromUrl: string | null;
+}
+
+/**
+ * 문항 생성/수정 페이지에서 뒤로가기 이벤트를 처리하는 훅
+ * - 새로 생성 중인 문항(questionIdFromUrl이 없는 경우): 뒤로가기 시 문항 삭제
+ * - 기존 문항 수정 중(questionIdFromUrl이 있는 경우): 뒤로가기만 수행
+ */
+export const useQuestionBackHandler = ({
+	questionId,
+	questionIdFromUrl,
+}: UseQuestionBackHandlerOptions) => {
+	const navigate = useNavigate();
+	const { deleteQuestion } = useSurvey();
+
+	useEffect(() => {
+		const unsubscription = graniteEvent.addEventListener("backEvent", {
+			onEvent: () => {
+				if (!questionIdFromUrl && questionId) {
+					deleteQuestion(questionId);
+				}
+				navigate(-1);
+			},
+		});
+
+		return unsubscription;
+	}, [navigate, questionIdFromUrl, questionId, deleteQuestion]);
+};

--- a/src/pages/QuestionForm/multipleChoice/MultipleChoiceMain.tsx
+++ b/src/pages/QuestionForm/multipleChoice/MultipleChoiceMain.tsx
@@ -1,4 +1,3 @@
-import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
 import {
 	Asset,
@@ -9,7 +8,6 @@ import {
 	ListRow,
 	Switch,
 } from "@toss/tds-mobile";
-import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 import { useSurvey } from "../../../contexts/SurveyContext";
@@ -18,11 +16,12 @@ import { pushGtmEvent } from "../../../utils/gtm";
 import { CreateMultiChoiceBottomSheet } from "../components/bottomSheet/CreateMultiChoiceBottomSheet";
 import { QuestionSelectionBottomSheet } from "../components/bottomSheet/QuestionSelectionBottomSheet";
 import { SelectionLimitBottomSheet } from "../components/bottomSheet/SelectionLimitBottomSheet";
+import { useQuestionBackHandler } from "../hooks/useQuestionBackHandler";
 import { useQuestionByType } from "../hooks/useQuestionByType";
 import { useCreateSurveyQuestion } from "../hooks/useQuestionMutations";
 
 export const MultipleChoiceMain = () => {
-	const { state, updateQuestion, deleteQuestion } = useSurvey();
+	const { state, updateQuestion } = useSurvey();
 	const { mutate: createSurveyQuestion } = useCreateSurveyQuestion();
 
 	const location = useLocation();
@@ -44,18 +43,7 @@ export const MultipleChoiceMain = () => {
 	const maxChoice = question?.maxChoice;
 	const options = question?.option ?? [];
 
-	useEffect(() => {
-		const unsubscription = graniteEvent.addEventListener("backEvent", {
-			onEvent: () => {
-				if (options.length === 0 && questionId) {
-					deleteQuestion(questionId);
-				}
-				navigate(-1);
-			},
-		});
-
-		return unsubscription;
-	}, [navigate, options.length, questionId, deleteQuestion]);
+	useQuestionBackHandler({ questionId, questionIdFromUrl });
 
 	const { isOpen, handleOpen, handleClose } = useModal(false);
 


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 설문 문항 작성 중 뒤로가기 버튼 누르면 문항 추가된 상태 초기화

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: 

## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->

https://github.com/user-attachments/assets/cac3a3c6-6302-44b8-9443-64bbe3432be8



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 질문 작성 중 뒤로 가기 시 새로 생성된(저장되지 않은) 질문이 자동으로 정리되어 설문에 남아있던 문제가 해결되었습니다.

* **리팩터**
  * 여러 질문 유형 페이지에서 뒤로 가기 동작이 일관되게 처리되도록 개선되어 탐색/복원 동작의 안정성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->