### PR TITLE
[OMF-102] 설문 페이지 접속시 스크리닝 여부 확인 후 리다이랙트

### DIFF
--- a/src/hooks/useSurveyInfo.ts
+++ b/src/hooks/useSurveyInfo.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	getSurveyInfo,
+	type SurveyBasicInfo,
+} from "../service/surveyParticipation";
+
+export const useSurveyInfo = (
+	surveyId?: number,
+	options?: {
+		enabled?: boolean;
+	},
+) => {
+	const { enabled = true } = options ?? {};
+
+	return useQuery<SurveyBasicInfo>({
+		queryKey: ["surveyInfo", surveyId],
+		queryFn: () => {
+			if (surveyId === undefined || surveyId === null) {
+				throw new Error("surveyId가 필요합니다.");
+			}
+			return getSurveyInfo(surveyId);
+		},
+		enabled: Boolean(surveyId) && enabled,
+	});
+};

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -10,6 +10,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { type InterestId, topics } from "../constants/topics";
+import { useSurveyInfo } from "../hooks/useSurveyInfo";
 import type { TransformedSurveyQuestion } from "../service/surveyParticipation";
 import { getSurveyParticipation } from "../service/surveyParticipation";
 import type { ReturnTo } from "../types/navigation";
@@ -35,6 +36,11 @@ export const Survey = () => {
 	const surveyIdFromState = locationState?.surveyId ?? surveyFromState?.id;
 	const surveyIdFromQuery = searchParams.get("surveyId");
 	const surveyId = surveyIdFromQuery ?? surveyIdFromState ?? null;
+	const numericSurveyId = useMemo(() => {
+		if (!surveyId) return null;
+		const parsed = Number(surveyId);
+		return Number.isNaN(parsed) ? null : parsed;
+	}, [surveyId]);
 
 	const [questions, setQuestions] = useState<TransformedSurveyQuestion[]>([]);
 	const [error, setError] = useState<string | null>(null);
@@ -78,14 +84,23 @@ export const Survey = () => {
 		});
 	}, [surveyId, locationState?.source, locationState?.quiz_id]);
 
+	const { data: surveyBasicInfoData } = useSurveyInfo(
+		numericSurveyId ?? undefined,
+		{ enabled: Boolean(numericSurveyId) },
+	);
+
 	useEffect(() => {
-		if (!surveyId) {
+		if (!numericSurveyId) {
 			return;
 		}
 
-		const numericSurveyId = Number(surveyId);
-		if (Number.isNaN(numericSurveyId)) {
-			setQuestions([]);
+		if (surveyBasicInfoData && !surveyBasicInfoData.isScreenRequired) {
+			setErrorDialog({
+				open: true,
+				title: "스크리닝이 필요합니다",
+				description: "스크리닝을 완료한 후 참여할 수 있어요.",
+				redirectTo: "/screening",
+			});
 			return;
 		}
 
@@ -182,6 +197,8 @@ export const Survey = () => {
 			isMounted = false;
 		};
 	}, [
+		numericSurveyId,
+		surveyBasicInfoData,
 		surveyId,
 		surveyFromState,
 		locationState?.source,

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -105,6 +105,17 @@ export const Survey = () => {
 			return;
 		}
 
+		if (surveyBasicInfoData?.isScreened) {
+			setErrorDialog({
+				open: true,
+				title: "스크리닝 조건이 맞지 않습니다",
+				description:
+					"설정하신 스크리닝 조건에 맞지 않아 설문에 참여할 수 없어요.",
+				redirectTo: "/",
+			});
+			return;
+		}
+
 		let isMounted = true;
 
 		const fetchSurveyParticipation = async () => {

--- a/src/service/surveyParticipation/api.ts
+++ b/src/service/surveyParticipation/api.ts
@@ -7,6 +7,7 @@ import {
 	type ScreeningResponse,
 	type SubmitScreeningResponsePayload,
 	type SubmitSurveyParticipationPayload,
+	type SurveyBasicInfo,
 	type SurveyParticipationInfo,
 	type TransformedSurveyQuestion,
 } from "./types";
@@ -73,6 +74,16 @@ export const getSurveyParticipation = async (
 		deadline: result.deadline,
 		isFree: result.isFree,
 	};
+};
+
+export const getSurveyInfo = async (
+	surveyId: number,
+): Promise<SurveyBasicInfo> => {
+	return apiCall<SurveyBasicInfo>({
+		method: "GET",
+		url: "/v1/survey-participation/surveys/info",
+		params: { surveyId },
+	});
 };
 
 //설문에 대한 응답 생성

--- a/src/service/surveyParticipation/types.ts
+++ b/src/service/surveyParticipation/types.ts
@@ -89,6 +89,17 @@ export interface SurveyParticipationInfo {
 	isFree?: boolean;
 }
 
+export interface SurveyBasicInfo {
+	surveyId: number;
+	title: string;
+	description: string;
+	deadline: string;
+	interests: string[];
+	responseCount: number;
+	isScreenRequired: boolean;
+	isFree: boolean;
+}
+
 // 프론트엔드에서 사용하는 변환된 문항 타입
 export interface TransformedSurveyQuestion {
 	questionId: number;

--- a/src/service/surveyParticipation/types.ts
+++ b/src/service/surveyParticipation/types.ts
@@ -112,6 +112,8 @@ export interface SurveyBasicInfo {
 	interests: string[];
 	responseCount: number;
 	isScreenRequired: boolean;
+	isScreened: boolean;
+	isSurveyResponded: boolean;
 	isFree: boolean;
 }
 


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

-  설문 조회 시 스크리닝 여부에 따라 스크리닝 퀴즈를 확인하도록 수정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
jira 링크: https://onsurvey.atlassian.net/browse/OMF-102

 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 설문 기본 정보(제목, 설명, 마감일, 관심사, 응답수 등) 조회 기능이 추가되었습니다.
  * 조회 결과에 기반한 스크리닝 흐름이 도입되어, 필요 시 스크리닝 페이지로 자동 리다이렉트하거나 참여 불가 안내를 표시합니다.

* **개선**
  * 설문 정보 조회와 화면 전환 로직이 안정화되어 데이터 로딩과 상태 반영이 더 일관되게 동작합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->