### PR TITLE
[OMF-96] 설문 참여 UX 개선 및 제한 해제 (기타 입력, 무료 설문 처리, 문항/인원 제한 해제)

### DIFF
--- a/src/components/surveyList/CustomSurveyList.tsx
+++ b/src/components/surveyList/CustomSurveyList.tsx
@@ -61,9 +61,7 @@ export const CustomSurveyList = ({
 									topProps={{ color: adaptive.green500 }}
 									middle={survey.title}
 									middleProps={{ color: adaptive.grey800, fontWeight: "bold" }}
-									bottom={
-										survey.isFree ? "보상이 없어요" : "3분이면 200원 획득"
-									}
+									bottom={survey.isFree ? "보상이 없어요" : "200원 획득"}
 									bottomProps={{ color: adaptive.grey600 }}
 								/>
 							}

--- a/src/components/surveyList/UrgentSurveyList.tsx
+++ b/src/components/surveyList/UrgentSurveyList.tsx
@@ -133,16 +133,14 @@ export const UrgentSurveyList = ({
 							)}
 							{typeof survey.isFree === "boolean" && (
 								<div className="flex items-center gap-1 mb-3">
-									{!survey.isFree && (
-										<Asset.Icon
-											frameShape={Asset.frameShape.CleanW16}
-											backgroundColor="transparent"
-											name="icon-money-bag-point-mono"
-											color={adaptive.grey600}
-											aria-hidden={true}
-											ratio="1/1"
-										/>
-									)}
+									<Asset.Icon
+										frameShape={Asset.frameShape.CleanW16}
+										backgroundColor="transparent"
+										name="icon-money-bag-point-mono"
+										color={adaptive.grey600}
+										aria-hidden={true}
+										ratio="1/1"
+									/>
 									<Text
 										color={adaptive.grey800}
 										typography="t7"

--- a/src/constants/payment.ts
+++ b/src/constants/payment.ts
@@ -6,8 +6,18 @@ export const DESIRED_PARTICIPANTS = [
 		hideUnCheckedCheckBox: false,
 		disabled: false,
 	},
-	{ name: "150명", value: "150", hideUnCheckedCheckBox: false, disabled: true },
-	{ name: "200명", value: "200", hideUnCheckedCheckBox: false, disabled: true },
+	{
+		name: "150명",
+		value: "150",
+		hideUnCheckedCheckBox: false,
+		disabled: false,
+	},
+	{
+		name: "200명",
+		value: "200",
+		hideUnCheckedCheckBox: false,
+		disabled: false,
+	},
 ];
 
 export type GenderCode = "ALL" | "MALE" | "FEMALE";

--- a/src/hooks/useSurveyNavigation.ts
+++ b/src/hooks/useSurveyNavigation.ts
@@ -227,6 +227,7 @@ export const useSurveyNavigation = ({
 					questions: allQuestions,
 					currentQuestionIndex: initialQuestionIndex + 1,
 					answers,
+					isFree: locationState?.isFree,
 					source: locationState?.source,
 				},
 			});

--- a/src/index.css
+++ b/src/index.css
@@ -46,4 +46,3 @@
 	--main-green: #15c67f;
 	--button-color: var(--main-green);
 }
-

--- a/src/index.css
+++ b/src/index.css
@@ -47,8 +47,3 @@
 	--button-color: var(--main-green);
 }
 
-.payment-bottom-sheet-select label:has(input[value="150"]),
-.payment-bottom-sheet-select label:has(input[value="200"]) {
-	color: #d1d5db !important;
-	opacity: 0.6 !important;
-}

--- a/src/pages/QuestionForm/QuestionHome.tsx
+++ b/src/pages/QuestionForm/QuestionHome.tsx
@@ -168,7 +168,7 @@ export const QuestionHome = () => {
 				}
 				description={
 					<ListHeader.DescriptionParagraph>
-						최대 15개까지 가능
+						문항을 추가하고 수정할 수 있어요
 					</ListHeader.DescriptionParagraph>
 				}
 				descriptionPosition="bottom"

--- a/src/pages/QuestionForm/components/controller/QuestionController.tsx
+++ b/src/pages/QuestionForm/components/controller/QuestionController.tsx
@@ -1,6 +1,6 @@
 import { generateHapticFeedback } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
-import { Asset, Text, useToast } from "@toss/tds-mobile";
+import { Asset, Text } from "@toss/tds-mobile";
 import { motion } from "framer-motion";
 import { useState } from "react";
 import { useLocation } from "react-router-dom";
@@ -23,7 +23,6 @@ export const QuestionController = ({ onPrevious }: QuestionControllerProps) => {
 	const { isOpen, handleOpen, handleClose } = useModal();
 	const location = useLocation();
 	const { state } = useSurvey();
-	const { openToast } = useToast();
 	const [selectedQuestionType, setSelectedQuestionType] =
 		useState<QuestionType | null>(null);
 
@@ -68,14 +67,6 @@ export const QuestionController = ({ onPrevious }: QuestionControllerProps) => {
 			question_type: questionTypeForEvent,
 		});
 
-		if (state.survey.question.length >= 15) {
-			openToast("문항은 최대 15개까지 생성이 가능해요.", {
-				type: "bottom",
-				lottie: "https://static.toss.im/lotties-common/error-yellow-spot.json",
-				higherThanCTA: true,
-			});
-			return;
-		}
 		setSelectedQuestionType(questionType as QuestionType);
 		handleOpen();
 	};

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -219,6 +219,7 @@ export const Survey = () => {
 					description: surveyInfo.description,
 					remainingTimeText: surveyInfo.remainingTimeText,
 					isClosed: surveyInfo.isClosed,
+					isFree: surveyInfo.isFree,
 				}
 			: null);
 
@@ -314,7 +315,7 @@ export const Survey = () => {
 								typography="t5"
 								fontWeight="semibold"
 							>
-								{surveyInfo?.isFree
+								{surveyFromState?.isFree === true || surveyInfo?.isFree === true
 									? "참여보상이 없는 설문이에요"
 									: "참여 보상 : 200원"}
 							</Text>

--- a/src/pages/payment/EstimatePage.tsx
+++ b/src/pages/payment/EstimatePage.tsx
@@ -359,7 +359,7 @@ export const EstimatePage = () => {
 						style={
 							{
 								"--button-background-color": "#15c67f",
-							} as any
+							} as React.CSSProperties
 						}
 					>
 						결제하기

--- a/src/pages/payment/PaymentProductPage.tsx
+++ b/src/pages/payment/PaymentProductPage.tsx
@@ -317,7 +317,9 @@ export const PaymentProductPage = () => {
 				disabled={!selectedCoinAmount}
 				loading={false}
 				onClick={handleNext}
-				style={{ "--button-background-color": "#15c67f" } as any}
+				style={
+					{ "--button-background-color": "#15c67f" } as React.CSSProperties
+				}
 			>
 				다음
 			</FixedBottomCTA>

--- a/src/pages/screening/ScreeningQuestion.tsx
+++ b/src/pages/screening/ScreeningQuestion.tsx
@@ -66,7 +66,9 @@ export const ScreeningQuestion = () => {
 			<FixedBottomCTA
 				disabled={!question.trim()}
 				onClick={handleNext}
-				style={{ "--button-background-color": "#15c67f" } as any}
+				style={
+					{ "--button-background-color": "#15c67f" } as React.CSSProperties
+				}
 			>
 				다음
 			</FixedBottomCTA>

--- a/src/pages/survey/SingleChoice.tsx
+++ b/src/pages/survey/SingleChoice.tsx
@@ -8,6 +8,7 @@ import {
 	ProgressBar,
 	Top,
 } from "@toss/tds-mobile";
+import { useEffect, useState } from "react";
 import { QuestionBadge } from "../../components/QuestionBadge";
 import { useSurveyNavigation } from "../../hooks/useSurveyNavigation";
 
@@ -26,22 +27,72 @@ export const SurveySingleChoice = () => {
 		questionType: "multipleChoice",
 	});
 
+	const currentAnswer = currentQuestion
+		? answers[currentQuestion.questionId]
+		: undefined;
+	const isOtherOptionSelected =
+		currentAnswer === "기타 (직접 입력)" ||
+		currentAnswer?.startsWith("기타 (직접 입력): ");
+
+	// 기존 답변에서 입력값 추출
+	const initialCustomInput =
+		isOtherOptionSelected && currentAnswer?.startsWith("기타 (직접 입력): ")
+			? currentAnswer.replace("기타 (직접 입력): ", "")
+			: "";
+
+	const [customInputValue, setCustomInputValue] =
+		useState<string>(initialCustomInput);
+
+	// 답변이 변경될 때 입력값 동기화
+	useEffect(() => {
+		if (
+			isOtherOptionSelected &&
+			currentAnswer?.startsWith("기타 (직접 입력): ")
+		) {
+			const inputValue = currentAnswer.replace("기타 (직접 입력): ", "");
+			setCustomInputValue(inputValue);
+		} else if (!isOtherOptionSelected) {
+			setCustomInputValue("");
+		}
+	}, [currentAnswer, isOtherOptionSelected]);
+
 	if (!currentQuestion) {
 		return null;
 	}
 
 	const handleOptionSelect = (optionContent: string) => {
-		const currentAnswer = answers[currentQuestion.questionId];
+		const isOtherOption = optionContent === "기타 (직접 입력)";
+
 		// 이미 선택된 항목을 다시 클릭하면 선택 해제
-		if (currentAnswer === optionContent) {
+		if (
+			currentAnswer === optionContent ||
+			currentAnswer?.startsWith("기타 (직접 입력): ")
+		) {
 			updateAnswer(currentQuestion.questionId, "");
+			setCustomInputValue("");
 		} else {
-			updateAnswer(currentQuestion.questionId, optionContent);
+			if (isOtherOption) {
+				// 기타 옵션 선택 시 입력 필드 초기화
+				setCustomInputValue("");
+				updateAnswer(currentQuestion.questionId, "기타 (직접 입력)");
+			} else {
+				updateAnswer(currentQuestion.questionId, optionContent);
+				setCustomInputValue("");
+			}
 		}
 	};
 
-	const hasAnswer = Boolean(answers[currentQuestion.questionId]);
+	const handleCustomInputChange = (value: string) => {
+		setCustomInputValue(value);
+		const fullAnswer = value.trim()
+			? `기타 (직접 입력): ${value}`
+			: "기타 (직접 입력)";
+		updateAnswer(currentQuestion.questionId, fullAnswer);
+	};
+
+	const hasAnswer = Boolean(currentAnswer);
 	const isRequired = currentQuestion.isRequired ?? false;
+	const hasCustomInput = currentQuestion.hasCustomInput ?? false;
 
 	return (
 		<div className="flex flex-col w-full h-screen">
@@ -70,34 +121,48 @@ export const SurveySingleChoice = () => {
 
 			<div className="px-2 flex-1 overflow-y-auto pb-28">
 				{currentQuestion?.options && currentQuestion.options.length > 0 ? (
-					<List role="radiogroup">
-						{currentQuestion.options.map((choice) => (
-							<ListRow
-								key={choice.optionId}
-								role="radio"
-								aria-checked={
-									answers[currentQuestion.questionId] === choice.content
-								}
-								onClick={() => handleOptionSelect(choice.content)}
-								contents={
-									<ListRow.Texts
-										type="1RowTypeA"
-										top={choice.content}
-										topProps={{ color: colors.grey700 }}
-									/>
-								}
-								right={
-									<Checkbox.Line
-										checked={
-											answers[currentQuestion.questionId] === choice.content
+					<>
+						<List role="radiogroup">
+							{currentQuestion.options.map((choice) => {
+								const isOtherOption = choice.content === "기타 (직접 입력)";
+								const isSelected =
+									currentAnswer === choice.content ||
+									(isOtherOption && isOtherOptionSelected);
+
+								return (
+									<ListRow
+										key={choice.optionId}
+										role="radio"
+										aria-checked={isSelected}
+										onClick={() => handleOptionSelect(choice.content)}
+										contents={
+											<ListRow.Texts
+												type="1RowTypeA"
+												top={choice.content}
+												topProps={{ color: colors.grey700 }}
+											/>
 										}
-										aria-hidden={true}
+										right={
+											<Checkbox.Line checked={isSelected} aria-hidden={true} />
+										}
+										verticalPadding="large"
 									/>
-								}
-								verticalPadding="large"
-							/>
-						))}
-					</List>
+								);
+							})}
+						</List>
+						{hasCustomInput && isOtherOptionSelected && (
+							<div className="px-4 mt-4">
+								<input
+									type="text"
+									value={customInputValue}
+									onChange={(e) => handleCustomInputChange(e.target.value)}
+									placeholder="내용을 입력해주세요"
+									className="w-full border border-solid border-gray-200 rounded-xl px-4 py-3 text-[15px] leading-6 outline-none focus:border-green-400"
+									aria-label="기타 직접 입력"
+								/>
+							</div>
+						)}
+					</>
 				) : (
 					<div className="flex items-center justify-center h-full">
 						<p className="text-gray-500">객관식 선택지가 없어요.</p>

--- a/src/pages/survey/SingleChoice.tsx
+++ b/src/pages/survey/SingleChoice.tsx
@@ -6,6 +6,7 @@ import {
 	List,
 	ListRow,
 	ProgressBar,
+	Text,
 	Top,
 } from "@toss/tds-mobile";
 import { useEffect, useState } from "react";
@@ -30,9 +31,7 @@ export const SurveySingleChoice = () => {
 	const currentAnswer = currentQuestion
 		? answers[currentQuestion.questionId]
 		: undefined;
-	const isOtherOptionSelected =
-		currentAnswer === "기타 (직접 입력)" ||
-		currentAnswer?.startsWith("기타 (직접 입력): ");
+	const isOtherOptionSelected = currentAnswer?.startsWith("기타 (직접 입력");
 
 	// 기존 답변에서 입력값 추출
 	const initialCustomInput =
@@ -51,7 +50,7 @@ export const SurveySingleChoice = () => {
 		) {
 			const inputValue = currentAnswer.replace("기타 (직접 입력): ", "");
 			setCustomInputValue(inputValue);
-		} else if (!isOtherOptionSelected) {
+		} else if (!isOtherOptionSelected && currentAnswer !== "기타 (직접 입력)") {
 			setCustomInputValue("");
 		}
 	}, [currentAnswer, isOtherOptionSelected]);
@@ -61,22 +60,13 @@ export const SurveySingleChoice = () => {
 	}
 
 	const handleOptionSelect = (optionContent: string) => {
-		const isOtherOption = optionContent === "기타 (직접 입력)";
-
 		// 이미 선택된 항목을 다시 클릭하면 선택 해제
-		if (
-			currentAnswer === optionContent ||
-			currentAnswer?.startsWith("기타 (직접 입력): ")
-		) {
+		if (currentAnswer === optionContent) {
 			updateAnswer(currentQuestion.questionId, "");
-			setCustomInputValue("");
 		} else {
-			if (isOtherOption) {
-				// 기타 옵션 선택 시 입력 필드 초기화
-				setCustomInputValue("");
-				updateAnswer(currentQuestion.questionId, "기타 (직접 입력)");
-			} else {
-				updateAnswer(currentQuestion.questionId, optionContent);
+			updateAnswer(currentQuestion.questionId, optionContent);
+			// 다른 옵션 선택 시 기타 입력값 초기화
+			if (isOtherOptionSelected) {
 				setCustomInputValue("");
 			}
 		}
@@ -84,15 +74,24 @@ export const SurveySingleChoice = () => {
 
 	const handleCustomInputChange = (value: string) => {
 		setCustomInputValue(value);
-		const fullAnswer = value.trim()
-			? `기타 (직접 입력): ${value}`
-			: "기타 (직접 입력)";
-		updateAnswer(currentQuestion.questionId, fullAnswer);
+		// 입력값이 있으면 자동으로 답변에 반영
+		const fullAnswer = value.trim() ? `기타 (직접 입력): ${value}` : "";
+		if (fullAnswer) {
+			updateAnswer(currentQuestion.questionId, fullAnswer);
+		} else {
+			// 입력값이 없으면 답변 초기화
+			updateAnswer(currentQuestion.questionId, "");
+		}
 	};
 
 	const hasAnswer = Boolean(currentAnswer);
 	const isRequired = currentQuestion.isRequired ?? false;
-	const hasCustomInput = currentQuestion.hasCustomInput ?? false;
+	// options 배열에 "기타 (직접 입력)"이 있거나 hasCustomInput이 true이면 입력 필드 표시
+	const hasCustomInput =
+		currentQuestion.hasCustomInput === true ||
+		currentQuestion.options?.some(
+			(option) => option.content === "기타 (직접 입력)",
+		) === true;
 
 	return (
 		<div className="flex flex-col w-full h-screen">
@@ -122,36 +121,52 @@ export const SurveySingleChoice = () => {
 			<div className="px-2 flex-1 overflow-y-auto pb-28">
 				{currentQuestion?.options && currentQuestion.options.length > 0 ? (
 					<>
-						<List role="radiogroup">
-							{currentQuestion.options.map((choice) => {
-								const isOtherOption = choice.content === "기타 (직접 입력)";
-								const isSelected =
-									currentAnswer === choice.content ||
-									(isOtherOption && isOtherOptionSelected);
+						{currentQuestion.options.filter(
+							(choice) => choice.content !== "기타 (직접 입력)",
+						).length > 0 && (
+							<List role="radiogroup">
+								{currentQuestion.options
+									.filter((choice) => choice.content !== "기타 (직접 입력)")
+									.map((choice) => {
+										const isSelected = currentAnswer === choice.content;
 
-								return (
-									<ListRow
-										key={choice.optionId}
-										role="radio"
-										aria-checked={isSelected}
-										onClick={() => handleOptionSelect(choice.content)}
-										contents={
-											<ListRow.Texts
-												type="1RowTypeA"
-												top={choice.content}
-												topProps={{ color: colors.grey700 }}
+										return (
+											<ListRow
+												key={choice.optionId}
+												role="radio"
+												aria-checked={isSelected}
+												onClick={() => handleOptionSelect(choice.content)}
+												contents={
+													<ListRow.Texts
+														type="1RowTypeA"
+														top={choice.content}
+														topProps={{ color: colors.grey700 }}
+													/>
+												}
+												right={
+													<Checkbox.Line
+														checked={isSelected}
+														aria-hidden={true}
+													/>
+												}
+												verticalPadding="large"
 											/>
-										}
-										right={
-											<Checkbox.Line checked={isSelected} aria-hidden={true} />
-										}
-										verticalPadding="large"
-									/>
-								);
-							})}
-						</List>
-						{hasCustomInput && isOtherOptionSelected && (
-							<div className="px-4 mt-4">
+										);
+									})}
+							</List>
+						)}
+						{hasCustomInput && (
+							<div
+								className={`px-6 ${currentQuestion.options.filter((choice) => choice.content !== "기타 (직접 입력)").length > 0 ? "mt-4" : ""}`}
+							>
+								<Text
+									color={colors.grey700}
+									typography="t6"
+									fontWeight="semibold"
+									className="mb-2"
+								>
+									기타 (직접 입력)
+								</Text>
 								<input
 									type="text"
 									value={customInputValue}
@@ -163,6 +178,25 @@ export const SurveySingleChoice = () => {
 							</div>
 						)}
 					</>
+				) : hasCustomInput ? (
+					<div className="px-6">
+						<Text
+							color={colors.grey700}
+							typography="t6"
+							fontWeight="semibold"
+							className="mb-2"
+						>
+							기타 (직접 입력)
+						</Text>
+						<input
+							type="text"
+							value={customInputValue}
+							onChange={(e) => handleCustomInputChange(e.target.value)}
+							placeholder="내용을 입력해주세요"
+							className="w-full border border-solid border-gray-200 rounded-xl px-4 py-3 text-[15px] leading-6 outline-none focus:border-green-400"
+							aria-label="기타 직접 입력"
+						/>
+					</div>
 				) : (
 					<div className="flex items-center justify-center h-full">
 						<p className="text-gray-500">객관식 선택지가 없어요.</p>


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 기타 입력 필드 표시 및 설문 응답 표시
- 문항 15개 제한 체크 로직 제거
- 150, 200명 제한 해제
- 중복 응답 체크


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: https://onsurvey.atlassian.net/jira/software/projects/OMF/boards/35?selectedIssue=OMF-97


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 설문 완료 후 자동 프로모션 지급 흐름 추가(재시도 및 지급 상태 표시, 무료 설문 건 별도 처리)

* **Improvements**
  * 단일선택 문항에 기타(직접 입력) 자유기입란 추가 및 결과 페이지에서 별도 표시
  * 참여자 모집 옵션에 150명·200명 활성화
  * 보상 문구 및 아이콘 표시 간소화(비유료 상태 반영), 완료 화면 문구·지연 안내 개선
  * 설문 문항 입력 제한 해제

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->