### PR TITLE
[OMF-114] 스크리닝 완료 후와 설문 완료 후 설문 캐싱 데이터 초기화 되게 수정

### DIFF
--- a/src/hooks/useCompleteSurvey.ts
+++ b/src/hooks/useCompleteSurvey.ts
@@ -1,0 +1,19 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { completeSurvey } from "../service/surveyParticipation";
+
+export const useCompleteSurvey = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({ surveyId }: { surveyId: number }) =>
+			completeSurvey(surveyId),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: ["surveyInfo", variables.surveyId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["surveyQuestions", variables.surveyId],
+			});
+		},
+	});
+};

--- a/src/hooks/useSubmitScreeningResponse.ts
+++ b/src/hooks/useSubmitScreeningResponse.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { submitScreeningResponse } from "../service/surveyParticipation";
+import type { SubmitScreeningResponsePayload } from "../service/surveyParticipation/types";
+
+export const useSubmitScreeningResponse = () => {
+	const queryClient = useQueryClient();
+
+	return useMutation({
+		mutationFn: ({
+			screeningId,
+			payload,
+		}: {
+			screeningId: number;
+			payload: SubmitScreeningResponsePayload;
+			surveyId?: number | null;
+		}) => submitScreeningResponse(screeningId, payload),
+		onSuccess: (_, variables) => {
+			queryClient.invalidateQueries({
+				queryKey: ["surveyInfo", variables.surveyId],
+			});
+			queryClient.invalidateQueries({
+				queryKey: ["surveyQuestions", variables.surveyId],
+			});
+		},
+	});
+};

--- a/src/hooks/useSurveyNavigation.ts
+++ b/src/hooks/useSurveyNavigation.ts
@@ -5,7 +5,6 @@ import { queryClient } from "../contexts/queryClient";
 import { issuePromotion } from "../service/promotion";
 import type { TransformedSurveyQuestion } from "../service/surveyParticipation";
 import {
-	completeSurvey,
 	getSurveyInfo,
 	sendSurveyHeartbeat,
 	submitSurveyParticipation,
@@ -13,6 +12,7 @@ import {
 import type { SurveyListItem } from "../types/surveyList";
 import { pushGtmEvent } from "../utils/gtm";
 import { getQuestionTypeRoute } from "../utils/questionRoute";
+import { useCompleteSurvey } from "./useCompleteSurvey";
 
 interface UseSurveyNavigationState {
 	surveyId?: string | null;
@@ -50,6 +50,7 @@ export const useSurveyNavigation = ({
 	const [answers, setAnswers] =
 		useState<Record<number, string>>(initialAnswers);
 	const [submitting, setSubmitting] = useState(false);
+	const { mutateAsync: completeSurveyMutation } = useCompleteSurvey();
 
 	const currentQuestion = allQuestions[initialQuestionIndex];
 	const isCurrentQuestionType =
@@ -210,13 +211,13 @@ export const useSurveyNavigation = ({
 
 			const isLastQuestion = initialQuestionIndex >= allQuestions.length - 1;
 			if (isLastQuestion) {
-				await completeSurvey(surveyId);
+				await completeSurveyMutation({ surveyId });
 
 				// 프로모션 지급 첫 시도
 				let promotionIssued: boolean | undefined;
 				try {
 					// 무료 설문 확인
-					const surveyInfo = await getSurveyInfo({ surveyId });
+					const surveyInfo = await getSurveyInfo(surveyId);
 					const isSurveyFree = surveyInfo.isFree === true;
 
 					if (!isSurveyFree) {

--- a/src/hooks/useSurveyQuestions.ts
+++ b/src/hooks/useSurveyQuestions.ts
@@ -1,0 +1,27 @@
+import { useQuery } from "@tanstack/react-query";
+import {
+	getSurveyQuestions,
+	type TransformedSurveyQuestion,
+} from "../service/surveyParticipation";
+
+interface UseSurveyQuestionsOptions {
+	enabled?: boolean;
+}
+
+export const useSurveyQuestions = (
+	surveyId?: number,
+	options?: UseSurveyQuestionsOptions,
+) => {
+	const { enabled = true } = options ?? {};
+
+	return useQuery<{ info: TransformedSurveyQuestion[] }>({
+		queryKey: ["surveyQuestions", surveyId],
+		queryFn: () => {
+			if (surveyId === undefined || surveyId === null) {
+				throw new Error("surveyId가 필요합니다.");
+			}
+			return getSurveyQuestions({ surveyId });
+		},
+		enabled: Boolean(surveyId) && enabled,
+	});
+};

--- a/src/pages/OxScreening.tsx
+++ b/src/pages/OxScreening.tsx
@@ -8,11 +8,11 @@ import {
 } from "@toss/tds-mobile";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useSubmitScreeningResponse } from "../hooks/useSubmitScreeningResponse";
 import {
 	getScreenings,
 	getSurveyInfo,
 	getSurveyParticipation,
-	submitScreeningResponse,
 } from "../service/surveyParticipation";
 import type { ScreeningQuestion } from "../service/surveyParticipation/types";
 import type { SurveyListItem } from "../types/surveyList";
@@ -31,6 +31,8 @@ export const OxScreening = () => {
 	const [isLoading, setIsLoading] = useState(true);
 	const [nextSurveyId, setNextSurveyId] = useState<number | null>(null);
 	const [responseCount, setResponseCount] = useState<number | null>(null);
+
+	const { mutateAsync: submitScreening } = useSubmitScreeningResponse();
 
 	// 스크리닝 설문 조회
 	useEffect(() => {
@@ -94,8 +96,10 @@ export const OxScreening = () => {
 		if (currentQuestion && selectedOption !== null) {
 			try {
 				const content = String(selectedOption);
-				await submitScreeningResponse(currentQuestion.screeningId, {
-					content,
+				await submitScreening({
+					screeningId: currentQuestion.screeningId,
+					payload: { content },
+					surveyId: nextSurveyId,
 				});
 				pushGtmEvent({
 					event: "complete_screening_quiz",
@@ -160,8 +164,10 @@ export const OxScreening = () => {
 		if (currentQuestion && selectedOption !== null) {
 			try {
 				const content = String(selectedOption);
-				await submitScreeningResponse(currentQuestion.screeningId, {
-					content,
+				await submitScreening({
+					screeningId: currentQuestion.screeningId,
+					payload: { content },
+					surveyId: nextSurveyId,
 				});
 				pushGtmEvent({
 					event: "complete_screening_quiz",

--- a/src/pages/Survey.tsx
+++ b/src/pages/Survey.tsx
@@ -12,8 +12,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { type InterestId, topics } from "../constants/topics";
 import { useSurveyInfo } from "../hooks/useSurveyInfo";
+import { useSurveyQuestions } from "../hooks/useSurveyQuestions";
 import type { TransformedSurveyQuestion } from "../service/surveyParticipation";
-import { getSurveyParticipation } from "../service/surveyParticipation";
 import type { ReturnTo } from "../types/navigation";
 import type { SurveyListItem } from "../types/surveyList";
 import { formatRemainingTime } from "../utils/FormatDate";
@@ -92,6 +92,11 @@ export const Survey = () => {
 		{ enabled: Boolean(numericSurveyId) },
 	);
 
+	const { data: surveyQuestionsData } = useSurveyQuestions(
+		numericSurveyId ?? undefined,
+		{ enabled: Boolean(numericSurveyId) },
+	);
+
 	useEffect(() => {
 		if (!numericSurveyId) {
 			return;
@@ -102,7 +107,7 @@ export const Survey = () => {
 				open: true,
 				title: "스크리닝이 필요합니다",
 				description: "스크리닝을 완료한 후 참여할 수 있어요.",
-				redirectTo: "/screening",
+				redirectTo: "/oxScreening",
 			});
 			return;
 		}
@@ -113,7 +118,7 @@ export const Survey = () => {
 				title: "스크리닝 조건이 맞지 않습니다",
 				description:
 					"설정하신 스크리닝 조건에 맞지 않아 설문에 참여할 수 없어요.",
-				redirectTo: "/",
+				redirectTo: "/home",
 			});
 			return;
 		}
@@ -123,9 +128,15 @@ export const Survey = () => {
 		const fetchSurveyParticipation = async () => {
 			try {
 				setError(null);
-				const result = await getSurveyParticipation({
-					surveyId: numericSurveyId,
-				});
+				const result = {
+					info: surveyQuestionsData?.info ?? [],
+					title: surveyBasicInfoData?.title ?? "",
+					description: surveyBasicInfoData?.description ?? "",
+					interests: surveyBasicInfoData?.interests ?? [],
+					deadline: surveyBasicInfoData?.deadline ?? "",
+					isFree: surveyBasicInfoData?.isFree ?? false,
+					responseCount: surveyBasicInfoData?.responseCount ?? 0,
+				};
 				if (!isMounted) {
 					return;
 				}
@@ -218,7 +229,9 @@ export const Survey = () => {
 		surveyFromState,
 		locationState?.source,
 		locationState?.quiz_id,
+		surveyQuestionsData?.info,
 	]);
+	surveyQuestionsData?.info;
 
 	const sortedQuestions = useMemo(
 		() =>

--- a/src/pages/survey/Complete.tsx
+++ b/src/pages/survey/Complete.tsx
@@ -71,7 +71,7 @@ export const SurveyComplete = () => {
 			}
 
 			try {
-				const surveyInfo = await getSurveyInfo({ surveyId });
+				const surveyInfo = await getSurveyInfo(surveyId);
 				const isSurveyFree = surveyInfo.isFree === true;
 				setIsFree(isSurveyFree);
 				return isSurveyFree;


### PR DESCRIPTION
fix: 스크리닝 완료 후와 설문 완료 후 설문 캐싱 데이터 초기화 되게 수정

## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 스크리닝 완료 후와 설문 완료 후 설문 캐싱 데이터 초기화 되게 수정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Linear 링크: 


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 오류 발생 시 리디렉션 경로 수정 (스크리닝 페이지 경로 및 기본 홈 경로 업데이트)

* **Refactor**
  * 설문 완료 및 스크리닝 응답 제출 흐름 개선
  * 설문 질문 데이터 관리 최적화를 통한 성능 향상

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->