### PR TITLE
[OMF-202] 설문 소개 페이지에서 스크롤이 덜 되는 문제

### DIFF
--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -185,7 +185,7 @@ export const Survey = () => {
 				}
 			/>
 			<div className="flex flex-col w-full h-screen">
-				<div className="flex-1 overflow-y-auto pb-0">
+				<div className="flex-1 overflow-y-auto pb-[150px]">
 					<Top
 						title={
 							surveyTitle ? (


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 설문 소개 페이지에서 스크롤이 덜 되는 문제

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크:  https://onsurvey.atlassian.net/browse/OMF-202

## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->
<img width="380" height="724" alt="스크린샷 2026-02-14 오후 9 17 22" src="https://github.com/user-attachments/assets/ab63a322-bdba-4fa2-9ee4-98e614955de7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일 개선**
  * 설문조사 페이지의 하단 여백을 개선하여 고정된 요소 근처의 화면 배치를 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->