### PR TITLE
[OMF-213] 섹션 분기 로직 통일 및 경로 추적 및 복수 선택, 응답자 수 분리

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@vitejs/plugin-react": "^5.0.4",
 		"lint-staged": "^16.2.3",
 		"orval": "^8.1.0",
+		"rolldown": "1.0.0-beta.41",
 		"typescript": "~5.9.3",
 		"vite": "npm:rolldown-vite@7.1.14"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       orval:
         specifier: ^8.1.0
         version: 8.2.0(typescript@5.9.3)
+      rolldown:
+        specifier: 1.0.0-beta.41
+        version: 1.0.0-beta.41
       typescript:
         specifier: ~5.9.3
         version: 5.9.3

--- a/src/features/mysurvey/hooks/useSurveyAnswerDetail.ts
+++ b/src/features/mysurvey/hooks/useSurveyAnswerDetail.ts
@@ -40,16 +40,20 @@ export const useSurveyAnswerDetail = (
 
 		const questions = answerDetails.detailInfoList.map((detail) => {
 			const questionType = mapApiQuestionTypeToComponentType(detail.type);
+			// 복수 선택 가능한 CHOICE 타입의 경우 respondentCount 사용
+			// 없으면 기존 방식으로 계산 (하위 호환성)
 			const responseCount =
-				(detail.type === "CHOICE" ||
-					detail.type === "RATING" ||
-					detail.type === "NPS") &&
-				detail.answerMap
-					? Object.values(detail.answerMap).reduce(
-							(sum, count) => sum + count,
-							0,
-						)
-					: detail.answerList?.length || 0;
+				detail.type === "CHOICE" && detail.respondentCount !== undefined
+					? detail.respondentCount
+					: (detail.type === "CHOICE" ||
+								detail.type === "RATING" ||
+								detail.type === "NPS") &&
+							detail.answerMap
+						? Object.values(detail.answerMap).reduce(
+								(sum, count) => sum + count,
+								0,
+							)
+						: detail.answerList?.length || 0;
 
 			return {
 				id: String(detail.questionId),

--- a/src/features/mysurvey/pages/SurveyResponseDetail.tsx
+++ b/src/features/mysurvey/pages/SurveyResponseDetail.tsx
@@ -106,15 +106,26 @@ export const SurveyResponseDetail = () => {
 		const path = getQuestionResultRoute(type);
 
 		const responseCount =
-			(questionDetail.type === "CHOICE" ||
-				questionDetail.type === "RATING" ||
-				questionDetail.type === "NPS") &&
-			questionDetail.answerMap
+			questionDetail.type === "CHOICE" &&
+			questionDetail.respondentCount !== undefined
+				? questionDetail.respondentCount
+				: (questionDetail.type === "CHOICE" ||
+							questionDetail.type === "RATING" ||
+							questionDetail.type === "NPS") &&
+						questionDetail.answerMap
+					? (Object.values(questionDetail.answerMap) as number[]).reduce(
+							(sum, count) => sum + (count as number),
+							0,
+						)
+					: questionDetail.answerList?.length || 0;
+
+		const totalAnswerCount =
+			questionDetail.type === "CHOICE" && questionDetail.answerMap
 				? (Object.values(questionDetail.answerMap) as number[]).reduce(
 						(sum, count) => sum + (count as number),
 						0,
 					)
-				: questionDetail.answerList?.length || 0;
+				: undefined;
 
 		navigate(path, {
 			state: {
@@ -132,6 +143,7 @@ export const SurveyResponseDetail = () => {
 				surveyTitle: surveyResponse?.title || "",
 				surveyStatus: surveyResponse?.status || "active",
 				responseCount,
+				totalAnswerCount,
 				surveyId: Number(surveyId),
 				filters,
 			},

--- a/src/features/mysurvey/pages/SurveyResponseDetail.tsx
+++ b/src/features/mysurvey/pages/SurveyResponseDetail.tsx
@@ -209,42 +209,47 @@ export const SurveyResponseDetail = () => {
 						verticalPadding="small"
 						horizontalPadding="small"
 					/>
-					{surveyResponse.questions.map((question) => (
-						<ListRow
-							key={question.id}
-							contents={
-								<ListRow.Texts
-									type="2RowTypeA"
-									top={`${question.order !== undefined ? question.order + 1 : parseInt(question.id, 10)}. ${question.title}`}
-									topProps={{ color: adaptive.grey800, fontWeight: "bold" }}
-									bottom={getQuestionTypeLabel(
-										question.type,
-										question.required,
-									)}
-									bottomProps={{ color: adaptive.grey600 }}
-								/>
-							}
-							right={
-								<div className="[&_button]:!text-[#15c67f]">
-									<Button
-										size="medium"
-										variant="weak"
-										onClick={() =>
-											handleResultNavigation(question.type, question.id)
-										}
-										style={
-											{
-												"--button-background-color": "#f0faf6",
-											} as React.CSSProperties
-										}
-									>
-										{question.responseCount}명
-									</Button>
-								</div>
-							}
-							verticalPadding="large"
-						/>
-					))}
+					{(() => {
+						const firstQuestionOrder = surveyResponse.questions[0]?.order;
+						const offset = firstQuestionOrder === 0 ? 1 : 0;
+
+						return surveyResponse.questions.map((question) => (
+							<ListRow
+								key={question.id}
+								contents={
+									<ListRow.Texts
+										type="2RowTypeA"
+										top={`${question.order !== undefined ? question.order + offset : parseInt(question.id, 10)}. ${question.title}`}
+										topProps={{ color: adaptive.grey800, fontWeight: "bold" }}
+										bottom={getQuestionTypeLabel(
+											question.type,
+											question.required,
+										)}
+										bottomProps={{ color: adaptive.grey600 }}
+									/>
+								}
+								right={
+									<div className="[&_button]:!text-[#15c67f]">
+										<Button
+											size="medium"
+											variant="weak"
+											onClick={() =>
+												handleResultNavigation(question.type, question.id)
+											}
+											style={
+												{
+													"--button-background-color": "#f0faf6",
+												} as React.CSSProperties
+											}
+										>
+											{question.responseCount}명
+										</Button>
+									</div>
+								}
+								verticalPadding="large"
+							/>
+						));
+					})()}
 				</List>
 			</div>
 

--- a/src/features/mysurvey/service/mysurvey/types.ts
+++ b/src/features/mysurvey/service/mysurvey/types.ts
@@ -80,6 +80,7 @@ export interface SurveyAnswerDetailInfo {
 	answerMap: Record<string, number>;
 	answerList: string[];
 	rate?: number;
+	respondentCount?: number; // 복수 선택 가능한 문항의 실제 응답자 수
 }
 
 export interface SurveyInfo {

--- a/src/features/screening/pages/OxScreening.tsx
+++ b/src/features/screening/pages/OxScreening.tsx
@@ -53,7 +53,10 @@ export const OxScreening = () => {
 					return;
 				}
 
-				const result = await getScreenings();
+				const result = await getScreenings({
+					lastSurveyId: 0,
+					size: 100,
+				});
 				if (result.data.length === 0) {
 					setShowNoQuiz(true);
 					return;

--- a/src/features/survey-list/pages/Home.tsx
+++ b/src/features/survey-list/pages/Home.tsx
@@ -151,9 +151,16 @@ export const Home = () => {
 						<>
 							{/* 설문 없음 UI */}
 							{hasNoSurveys && (
-								<div className="px-4 pb-4">
+								<div className="p-4">
+									<Text
+										color={adaptive.grey800}
+										typography="t4"
+										fontWeight="bold"
+									>
+										지금 열려있는 설문
+									</Text>
 									<div
-										className="rounded-2xl px-4 py-8 flex flex-col items-center justify-center gap-2 min-h-[140px]"
+										className="rounded-2xl px-4 py-8 flex flex-col items-center justify-center gap-2 min-h-[140px] mt-2"
 										style={{ backgroundColor: adaptive.grey50 }}
 									>
 										<Asset.Icon

--- a/src/features/survey-result/constants/survey.ts
+++ b/src/features/survey-result/constants/survey.ts
@@ -15,7 +15,7 @@ export const SURVEY_STATUS_LABELS: Record<SurveyStatus, string> = {
 // 질문 타입별 라벨
 export const QUESTION_TYPE_LABELS: Record<string, string> = {
 	shortAnswer: "주관식 단답형",
-	longAnswer: "주관식 서술형",
+	longAnswer: "주관식 장문형",
 	multipleChoice: "객관식",
 	rating: "평가형",
 	nps: "NPS",

--- a/src/features/survey-result/hooks/useResultPageData.ts
+++ b/src/features/survey-result/hooks/useResultPageData.ts
@@ -12,6 +12,7 @@ export const useResultPageData = () => {
 	const surveyTitle = state?.surveyTitle || "설문 제목";
 	const surveyStatus = state?.surveyStatus || "active";
 	const responseCount = state?.responseCount || 0;
+	const totalAnswerCount = state?.totalAnswerCount;
 	const isRequired = question?.isRequired ?? true;
 
 	const requiredLabel = isRequired ? "필수" : "선택";
@@ -23,6 +24,7 @@ export const useResultPageData = () => {
 		surveyTitle,
 		surveyStatus,
 		responseCount,
+		totalAnswerCount,
 		isRequired,
 		requiredLabel,
 	};

--- a/src/features/survey-result/pages/MultipleChoiceResultPage.tsx
+++ b/src/features/survey-result/pages/MultipleChoiceResultPage.tsx
@@ -92,9 +92,9 @@ export const MultipleChoiceResultPage = () => {
 						variant="weak"
 						display="inline"
 					>
-						{totalAnswerCount !== undefined && totalAnswerCount > responseCount
-							? `${responseCount}명 응답 · 총 ${totalAnswerCount}개 답변`
-							: `${responseCount || totalResponses}명 응답`}
+						{totalResponses === 0 || totalResponses > responseCount
+							? `${responseCount}명 응답 · 총 ${totalResponses}개 답변`
+							: `${responseCount}명 응답`}
 					</Top.LowerButton>
 				}
 			/>

--- a/src/features/survey-result/pages/MultipleChoiceResultPage.tsx
+++ b/src/features/survey-result/pages/MultipleChoiceResultPage.tsx
@@ -20,6 +20,7 @@ export const MultipleChoiceResultPage = () => {
 		surveyTitle,
 		surveyStatus,
 		responseCount,
+		totalAnswerCount,
 		requiredLabel,
 	} = useResultPageData();
 
@@ -56,11 +57,9 @@ export const MultipleChoiceResultPage = () => {
 
 	const maxCount =
 		options.length > 0 ? Math.max(...options.map((o) => o.count)) : 0;
-	// answerMap의 모든 값의 합이 전체 응답 수 (기타 응답 포함)
-	const totalResponses = Object.values(answerMap).reduce(
-		(sum, count) => sum + count,
-		0,
-	);
+	const totalResponses =
+		totalAnswerCount ??
+		Object.values(answerMap).reduce((sum, count) => sum + count, 0);
 
 	return (
 		<div className="min-h-screen">
@@ -93,7 +92,9 @@ export const MultipleChoiceResultPage = () => {
 						variant="weak"
 						display="inline"
 					>
-						{totalResponses || responseCount}명 응답
+						{totalAnswerCount !== undefined && totalAnswerCount > responseCount
+							? `${responseCount}명 응답 · 총 ${totalAnswerCount}개 답변`
+							: `${responseCount || totalResponses}명 응답`}
 					</Top.LowerButton>
 				}
 			/>

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -242,7 +242,7 @@ export const SectionBasedSurvey = () => {
 			// 첫 섹션인 경우 Survey 페이지로 이동
 			navigate(`/survey?surveyId=${surveyId}`, { replace: true });
 		} else {
-			const currentIndex = sectionHistory.indexOf(currentSection);
+			const currentIndex = sectionHistory.lastIndexOf(currentSection);
 			let prevSection: number;
 			let newHistory: number[];
 

--- a/src/shared/lib/questionFactory.ts
+++ b/src/shared/lib/questionFactory.ts
@@ -7,7 +7,9 @@ export const mapApiQuestionTypeToComponentType = (
 	const typeMap: Record<string, QuestionType> = {
 		CHOICE: "multipleChoice",
 		SHORT_ANSWER: "shortAnswer",
+		SHORT: "shortAnswer",
 		LONG_ANSWER: "longAnswer",
+		LONG: "longAnswer",
 		RATING: "rating",
 		NPS: "nps",
 		DATE: "date",

--- a/src/shared/types/surveyResponse.ts
+++ b/src/shared/types/surveyResponse.ts
@@ -40,7 +40,8 @@ export interface ResultPageState {
 	answerList?: string[];
 	surveyTitle: string;
 	surveyStatus: "active" | "closed";
-	responseCount: number;
+	responseCount: number; // 실제 응답자 수 (respondentCount)
+	totalAnswerCount?: number; // 총 답변 수 (복수 선택 시 responseCount보다 많을 수 있음)
 	surveyId?: number;
 	filters?: {
 		ages?: string[];


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 섹션 분기 로직 통일 및 경로 추적
- 복수 선택, 응답자 수 분리
- 문항 번호 표시 로적 수정


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-213


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 객관식 문항에 respondentCount 우선 반영 및 totalAnswerCount 전달·표시 추가
  * 섹션 기반 설문에 섹션 히스토리 도입으로 이전/다음 이동 경로 보존

* **Bug Fixes**
  * 복수 선택 문항 응답 수 집계 로직 개선(respondentCount 우선, 기존 집계 폴백)
  * 항목 번호 표시 일관성 개선(질문 순서 오프셋 적용)

* **Chores**
  * 긴문항 레이블 수정, 질문 유형 매핑 보강 및 홈 화면 레이아웃·타깃 설문 탐색 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->