### PR TITLE
[OMF-247] 설문 페이지에서 로그인 여부 확인 속도 개선

### DIFF
--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -47,32 +47,40 @@ export const Survey = () => {
 
 	useEffect(() => {
 		let isMounted = true;
+		const loginRequiredDialog = {
+			open: true,
+			title: "로그인이 필요합니다",
+			description: "로그인 후 이용해주세요",
+			redirectTo: "/",
+			returnTo: {
+				path: `${location.pathname}${location.search}${location.hash}`,
+				state:
+					locationState && typeof locationState === "object"
+						? (locationState as Record<string, unknown>)
+						: undefined,
+			},
+		};
 
 		const checkAuthToken = async () => {
-			const [accessToken, refreshToken] = await Promise.all([
-				getAccessToken(),
-				getRefreshToken(),
-			]);
+			try {
+				const [accessToken, refreshToken] = await Promise.all([
+					getAccessToken(),
+					getRefreshToken(),
+				]);
 
-			if (!isMounted) return;
+				if (!isMounted) return;
 
-			const hasToken = Boolean(accessToken || refreshToken);
-			setHasAuthToken(hasToken);
+				const hasToken = Boolean(accessToken || refreshToken);
+				setHasAuthToken(hasToken);
 
-			if (!hasToken) {
-				setErrorDialog({
-					open: true,
-					title: "로그인이 필요합니다",
-					description: "로그인 후 이용해주세요",
-					redirectTo: "/",
-					returnTo: {
-						path: `${location.pathname}${location.search}${location.hash}`,
-						state:
-							locationState && typeof locationState === "object"
-								? (locationState as Record<string, unknown>)
-								: undefined,
-					},
-				});
+				if (!hasToken) {
+					setErrorDialog(loginRequiredDialog);
+				}
+			} catch (error) {
+				console.error("토큰 확인 실패:", error);
+				if (!isMounted) return;
+				setHasAuthToken(false);
+				setErrorDialog(loginRequiredDialog);
 			}
 		};
 
@@ -167,10 +175,15 @@ export const Survey = () => {
 		if (hasAuthToken === false) return;
 
 		const handleError = async () => {
-			const authError = await getAuthErrorFromException(apiError);
-			if (authError) {
-				setErrorDialog(authError);
-			} else {
+			try {
+				const authError = await getAuthErrorFromException(apiError);
+				if (authError) {
+					setErrorDialog(authError);
+					return;
+				}
+				setError("설문 정보를 불러오지 못했습니다.");
+			} catch (error) {
+				console.error("설문 에러 처리 실패:", error);
 				setError("설문 정보를 불러오지 못했습니다.");
 			}
 		};

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -1,6 +1,7 @@
 import type { InterestId } from "@shared/constants/topics";
 import { formatRemainingTime } from "@shared/lib/FormatDate";
 import { shareSurveyById } from "@shared/lib/shareSurvey";
+import { getAccessToken, getRefreshToken } from "@shared/lib/tokenManager";
 import type { ReturnTo } from "@shared/types/navigation";
 import { colors } from "@toss/tds-colors";
 import {
@@ -14,7 +15,7 @@ import {
 	useToast,
 } from "@toss/tds-mobile";
 import { useEffect, useMemo, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { SurveyRewardInfoCard } from "../components/SurveyRewardInfoCard";
 import { useSurveyAccessCheck } from "../hooks/useSurveyAccessCheck";
 import { useSurveyDisplayInfo } from "../hooks/useSurveyDisplayInfo";
@@ -24,6 +25,7 @@ import { useSurveyRouteParams } from "../hooks/useSurveyRouteParams";
 
 export const Survey = () => {
 	const navigate = useNavigate();
+	const location = useLocation();
 	const { openToast } = useToast();
 
 	const [error, setError] = useState<string | null>(null);
@@ -38,9 +40,48 @@ export const Survey = () => {
 		open: false,
 		title: "",
 	});
+	const [hasAuthToken, setHasAuthToken] = useState<boolean | null>(null);
 
 	const { surveyId, numericSurveyId, surveyFromState, locationState } =
 		useSurveyRouteParams();
+
+	useEffect(() => {
+		let isMounted = true;
+
+		const checkAuthToken = async () => {
+			const [accessToken, refreshToken] = await Promise.all([
+				getAccessToken(),
+				getRefreshToken(),
+			]);
+
+			if (!isMounted) return;
+
+			const hasToken = Boolean(accessToken || refreshToken);
+			setHasAuthToken(hasToken);
+
+			if (!hasToken) {
+				setErrorDialog({
+					open: true,
+					title: "로그인이 필요합니다",
+					description: "로그인 후 이용해주세요",
+					redirectTo: "/",
+					returnTo: {
+						path: `${location.pathname}${location.search}${location.hash}`,
+						state:
+							locationState && typeof locationState === "object"
+								? (locationState as Record<string, unknown>)
+								: undefined,
+					},
+				});
+			}
+		};
+
+		void checkAuthToken();
+
+		return () => {
+			isMounted = false;
+		};
+	}, [location.hash, location.pathname, location.search, locationState]);
 
 	// 설문 기본 정보 (제목, 설명, 마감일, 보상 여부, 스크리닝 필요 여부 등)
 	const {
@@ -49,13 +90,13 @@ export const Survey = () => {
 		isLoading: isSurveyBasicInfoLoading,
 		isFetching: isSurveyBasicInfoFetching,
 	} = useSurveyInfo(numericSurveyId ?? undefined, {
-		enabled: Boolean(numericSurveyId),
+		enabled: Boolean(numericSurveyId) && hasAuthToken === true,
 	});
 
 	// 설문 문항 목록
 	const { data: surveyQuestionsData, error: surveyQuestionsError } =
 		useSurveyQuestions(numericSurveyId ?? undefined, {
-			enabled: Boolean(numericSurveyId),
+			enabled: Boolean(numericSurveyId) && hasAuthToken === true,
 		});
 
 	const surveyInfo = useMemo(() => {
@@ -101,8 +142,9 @@ export const Survey = () => {
 	);
 	const screeningError = getScreeningError();
 	const isAccessChecking =
-		Boolean(numericSurveyId) &&
-		(isSurveyBasicInfoLoading || isSurveyBasicInfoFetching);
+		hasAuthToken === null ||
+		(Boolean(numericSurveyId) &&
+			(isSurveyBasicInfoLoading || isSurveyBasicInfoFetching));
 	const isStartDisabled =
 		isClosed ||
 		sortedQuestions.length === 0 ||
@@ -122,6 +164,7 @@ export const Survey = () => {
 			setError(null);
 			return;
 		}
+		if (hasAuthToken === false) return;
 
 		const handleError = async () => {
 			const authError = await getAuthErrorFromException(apiError);
@@ -132,7 +175,7 @@ export const Survey = () => {
 			}
 		};
 		void handleError();
-	}, [apiError, getAuthErrorFromException]);
+	}, [apiError, getAuthErrorFromException, hasAuthToken]);
 
 	const handleStart = () => {
 		if (isStartDisabled) {


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 설문 페이지에서 로그인 여부 확인 속도 개선

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-247

## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설문 화면에 토큰 기반 접근 제어 추가
  * 인증이 필요한 경우 로그인 안내 다이얼로그 표시 및 로그인 후 이전 페이지로 자동 복귀

* **버그 수정**
  * 토큰 검증이 완료된 후에만 설문 데이터 로드 시작하도록 개선
  * 인증/오류 처리 로직 강화로 인증 실패 시 적절한 안내 표시 및 불필요한 요청 차단
<!-- end of auto-generated comment: release notes by coderabbit.ai -->