### PR TITLE
[OMF-258] 문항 수에 따른 프로모션 가격 변경 UI 수정

### DIFF
--- a/src/features/survey-list/components/CustomSurveyList.tsx
+++ b/src/features/survey-list/components/CustomSurveyList.tsx
@@ -241,7 +241,7 @@ export const CustomSurveyList = ({ surveys }: CustomSurveyListProps) => {
 											color: "#DD7D02",
 										}}
 									>
-										200원
+										{survey.price ?? 200}원
 									</Text>
 								</div>
 							)}

--- a/src/features/survey-list/components/SurveyList.tsx
+++ b/src/features/survey-list/components/SurveyList.tsx
@@ -1,3 +1,4 @@
+import { getEstimatedTimeByPrice } from "@features/survey/components/SurveyRewardInfoCard";
 import { TextWithLinks } from "@features/survey/components/TextWithLinks";
 import { topics } from "@shared/constants/topics";
 import { pushGtmEvent } from "@shared/lib/gtm";
@@ -77,7 +78,7 @@ export const SurveyList = ({ surveys }: SurveyListProps) => {
 								bottom={
 									survey.isFree
 										? "보상이 없어요"
-										: `3분이면 ${survey.price ?? 200}원 획득`
+										: `${getEstimatedTimeByPrice(survey.price)}분이면 ${survey.price ?? 200}원 획득`
 								}
 								bottomProps={{ color: adaptive.grey600 }}
 							/>

--- a/src/features/survey-list/components/SurveyList.tsx
+++ b/src/features/survey-list/components/SurveyList.tsx
@@ -74,7 +74,11 @@ export const SurveyList = ({ surveys }: SurveyListProps) => {
 									/>
 								}
 								middleProps={{ color: adaptive.grey800, fontWeight: "bold" }}
-								bottom={survey.isFree ? "보상이 없어요" : "3분이면 200원 획득"}
+								bottom={
+									survey.isFree
+										? "보상이 없어요"
+										: `3분이면 ${survey.price ?? 200}원 획득`
+								}
 								bottomProps={{ color: adaptive.grey600 }}
 							/>
 						}

--- a/src/features/survey-list/components/UrgentSurveyList.tsx
+++ b/src/features/survey-list/components/UrgentSurveyList.tsx
@@ -162,7 +162,9 @@ export const UrgentSurveyList = ({
 										typography="t7"
 										fontWeight="semibold"
 									>
-										{survey.isFree ? "보상이 없어요" : "200원"}
+										{survey.isFree
+											? "보상이 없어요"
+											: `${survey.price ?? 200}원`}
 									</Text>
 								</div>
 							)}

--- a/src/features/survey-list/hooks/useProcessedOngoingSurveys.ts
+++ b/src/features/survey-list/hooks/useProcessedOngoingSurveys.ts
@@ -14,13 +14,6 @@ export interface ProcessedOngoingSurveysResult {
 	totalPromotionAmount: number;
 }
 
-/**
- * 진행 중인 설문 API 결과를 홈/리스트용 데이터로 가공하는 훅.
- *
- * - 추천/임박 설문을 UI용 SurveyListItem으로 변환
- * - 마감된 설문(remainingTime === "마감됨") 제외
- * - 추천·임박 합산 고유 설문 수 × 200으로 프로모션 총액 계산
- */
 export const useProcessedOngoingSurveys = (
 	result:
 		| {
@@ -59,6 +52,7 @@ export const useProcessedOngoingSurveys = (
 				isClosed: remainingTime === "마감됨",
 				isFree: survey.isFree,
 				responseCount: survey.responseCount,
+				price: survey.price,
 			};
 		};
 
@@ -80,8 +74,17 @@ export const useProcessedOngoingSurveys = (
 			result.recommended,
 			result.impending,
 		);
-
-		const totalAmount = uniqueSurveyIds.size * 200;
+		const surveyIdToPrice = new Map<number, number>();
+		for (const s of [
+			...(result.recommended ?? []),
+			...(result.impending ?? []),
+		]) {
+			surveyIdToPrice.set(s.surveyId, s.price ?? 200);
+		}
+		const totalAmount = Array.from(uniqueSurveyIds).reduce(
+			(sum, id) => sum + (surveyIdToPrice.get(id) ?? 200),
+			0,
+		);
 
 		return {
 			recommended: rec,

--- a/src/features/survey-list/pages/SurveyList.tsx
+++ b/src/features/survey-list/pages/SurveyList.tsx
@@ -89,6 +89,7 @@ export const SurveyListPage = () => {
 				iconName: topic?.icon.type === "icon" ? topic.icon.name : undefined,
 				description: survey.description,
 				isFree: survey.isFree,
+				price: survey.price,
 			};
 		};
 

--- a/src/features/survey-list/service/surveyList/types.ts
+++ b/src/features/survey-list/service/surveyList/types.ts
@@ -17,6 +17,7 @@ export interface OngoingSurveySummary {
 	isFree?: boolean;
 	responseCount?: number;
 	isEligible?: boolean; // 세그먼트 일치 여부 (true: 일치, false: 불일치)
+	price?: number;
 }
 
 export interface OngoingSurveyResult {

--- a/src/features/survey/components/SurveyRewardInfoCard.tsx
+++ b/src/features/survey/components/SurveyRewardInfoCard.tsx
@@ -1,10 +1,13 @@
 import { colors } from "@toss/tds-colors";
 import { Text } from "@toss/tds-mobile";
 
+const DEFAULT_REWARD_PRICE = 200;
+
 interface SurveyRewardInfoCardProps {
 	isFree?: boolean;
 	questionCount: number;
 	remainingTimeText?: string | null;
+	price?: number;
 }
 
 const getEstimatedTime = (questionCount: number): number => {
@@ -17,14 +20,18 @@ export const SurveyRewardInfoCard = ({
 	isFree,
 	questionCount,
 	remainingTimeText,
+	price,
 }: SurveyRewardInfoCardProps) => {
 	const estimatedTime = getEstimatedTime(questionCount);
+	const rewardPrice = price ?? DEFAULT_REWARD_PRICE;
 
 	return (
 		<div className="px-4">
 			<div className="w-full rounded-2xl border border-green-500 p-5 shadow-sm">
 				<Text color={colors.grey900} typography="t5" fontWeight="semibold">
-					{isFree === true ? "참여보상이 없는 설문이에요" : "참여 보상 : 200원"}
+					{isFree === true
+						? "참여보상이 없는 설문이에요"
+						: `참여 보상 : ${rewardPrice}원`}
 				</Text>
 				<div className="h-2" />
 				<Text color={colors.grey900} typography="t5" fontWeight="semibold">

--- a/src/features/survey/components/SurveyRewardInfoCard.tsx
+++ b/src/features/survey/components/SurveyRewardInfoCard.tsx
@@ -10,11 +10,14 @@ interface SurveyRewardInfoCardProps {
 	price?: number;
 }
 
+export const getEstimatedTimeByPrice = (price?: number): number =>
+	(price ?? DEFAULT_REWARD_PRICE) === 500 ? 4 : 3;
+
 const getEstimatedTime = (
 	questionCount: number,
 	rewardPrice: number,
 ): number => {
-	if (rewardPrice === 500) return 4;
+	if (rewardPrice === 500) return getEstimatedTimeByPrice(rewardPrice);
 	if (questionCount <= 10) return 2;
 	if (questionCount <= 20) return 4;
 	return 4;

--- a/src/features/survey/components/SurveyRewardInfoCard.tsx
+++ b/src/features/survey/components/SurveyRewardInfoCard.tsx
@@ -10,7 +10,11 @@ interface SurveyRewardInfoCardProps {
 	price?: number;
 }
 
-const getEstimatedTime = (questionCount: number): number => {
+const getEstimatedTime = (
+	questionCount: number,
+	rewardPrice: number,
+): number => {
+	if (rewardPrice === 500) return 4;
 	if (questionCount <= 10) return 2;
 	if (questionCount <= 20) return 4;
 	return 4;
@@ -22,8 +26,11 @@ export const SurveyRewardInfoCard = ({
 	remainingTimeText,
 	price,
 }: SurveyRewardInfoCardProps) => {
-	const estimatedTime = getEstimatedTime(questionCount);
-	const rewardPrice = price ?? DEFAULT_REWARD_PRICE;
+	const rewardPrice =
+		price != null && Number.isFinite(Number(price))
+			? Number(price)
+			: DEFAULT_REWARD_PRICE;
+	const estimatedTime = getEstimatedTime(questionCount, rewardPrice);
 
 	return (
 		<div className="px-4">

--- a/src/features/survey/hooks/useSurveyNavigation.ts
+++ b/src/features/survey/hooks/useSurveyNavigation.ts
@@ -206,9 +206,10 @@ export const useSurveyNavigation = ({
 
 				// 프로모션 지급 첫 시도
 				let promotionIssued: boolean | undefined;
+				let surveyInfo: Awaited<ReturnType<typeof getSurveyInfo>> | undefined;
 				try {
 					// 무료 설문 확인
-					const surveyInfo = await getSurveyInfo(surveyId);
+					surveyInfo = await getSurveyInfo(surveyId);
 					const isSurveyFree = surveyInfo.isFree === true;
 
 					if (!isSurveyFree) {
@@ -258,6 +259,7 @@ export const useSurveyNavigation = ({
 						isFree: locationState?.isFree,
 						source: locationState?.source,
 						promotionIssued, // 프로모션 지급 성공 여부 전달
+						price: surveyInfo?.price,
 					},
 				});
 				return;

--- a/src/features/survey/hooks/useSurveyNavigation.ts
+++ b/src/features/survey/hooks/useSurveyNavigation.ts
@@ -263,7 +263,7 @@ export const useSurveyNavigation = ({
 					replace: true,
 					state: {
 						surveyId,
-						isFree: locationState?.isFree,
+						isFree: surveyInfo?.isFree ?? locationState?.isFree,
 						source: locationState?.source,
 						promotionIssued, // 프로모션 지급 성공 여부 전달
 						price: surveyInfo?.price,

--- a/src/features/survey/pages/Complete.tsx
+++ b/src/features/survey/pages/Complete.tsx
@@ -27,6 +27,7 @@ export const SurveyComplete = () => {
 				isFree?: boolean;
 				source?: "main" | "quiz" | "after_complete";
 				promotionIssued?: boolean;
+				price?: number;
 		  }
 		| undefined;
 	const surveyIdFromState = locationState?.surveyId;
@@ -57,9 +58,14 @@ export const SurveyComplete = () => {
 			pagePath: "/survey/complete",
 			survey_id: String(surveyId),
 			source,
-			reward_amount: "200",
+			reward_amount: String(locationState?.price ?? 200),
 		});
-	}, [state.surveyId, surveyIdFromState, locationState?.source]);
+	}, [
+		state.surveyId,
+		surveyIdFromState,
+		locationState?.source,
+		locationState?.price,
+	]);
 
 	const checkIfSurveyIsFree = useCallback(
 		async (surveyId: number): Promise<boolean> => {

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -311,8 +311,9 @@ export const SectionBasedSurvey = () => {
 		setSubmitting(true);
 		await completeSurveyMutation({ surveyId });
 
+		let surveyInfo: Awaited<ReturnType<typeof getSurveyInfo>> | undefined;
 		try {
-			const surveyInfo = await getSurveyInfo(surveyId);
+			surveyInfo = await getSurveyInfo(surveyId);
 			if (!surveyInfo.isFree) {
 				await issuePromotion({ surveyId });
 			}
@@ -326,6 +327,7 @@ export const SectionBasedSurvey = () => {
 			state: {
 				surveyId: String(surveyId),
 				source: locationState?.source,
+				price: surveyInfo?.price,
 			},
 		});
 	};

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -351,8 +351,6 @@ export const SectionBasedSurvey = () => {
 		await handleSubmit();
 	};
 
-	if (questions.length === 0) return null;
-
 	return (
 		<>
 			<Top

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -299,7 +299,7 @@ export const Survey = () => {
 						isFree={isFree}
 						questionCount={sortedQuestions.length}
 						remainingTimeText={remainingTimeText}
-						price={surveyBasicInfoData?.price}
+						price={surveyBasicInfoData?.price ?? surveyFromState?.price}
 					/>
 					<div className="px-4 mt-4">
 						<Button

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -299,6 +299,7 @@ export const Survey = () => {
 						isFree={isFree}
 						questionCount={sortedQuestions.length}
 						remainingTimeText={remainingTimeText}
+						price={surveyBasicInfoData?.price}
 					/>
 					<div className="px-4 mt-4">
 						<Button

--- a/src/features/survey/service/surveyParticipation/types.ts
+++ b/src/features/survey/service/surveyParticipation/types.ts
@@ -149,6 +149,7 @@ export interface SurveyBasicInfo {
 	isScreened: boolean;
 	isSurveyResponded: boolean;
 	isFree: boolean;
+	price?: number;
 }
 
 // 프론트엔드에서 사용하는 변환된 문항 타입

--- a/src/shared/types/surveyList.ts
+++ b/src/shared/types/surveyList.ts
@@ -12,4 +12,5 @@ export interface SurveyListItem {
 	isClosed?: boolean;
 	isFree?: boolean;
 	responseCount?: number;
+	price?: number;
 }


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 프로모션 가격 300/500 변경에 따른 UI 수정
- 문항 없는 섹션일 때도 타이틀/ 설명 표시
- 참여 보상에 따른 소요시간 출력 -> 500원 4분


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-258, https://onsurvey.atlassian.net/browse/OMF-256


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  




## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->
<table>
  <tr>
    <th>페이지 1</th>
    <th>페이지 2</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/b8afd329-4b54-42ca-bc81-6f2dbaf4d80a" width="320" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/0027bef8-a25a-42ef-b39b-134d446c61ef" width="320" />
    </td>
  </tr>
</table>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 설문 목록 및 긴급 설문에 보상금액을 동적으로 표시합니다. 금액이 없으면 기본값이 적용됩니다.
  * 설문 카드에 금액 기반 예상 소요시간을 함께 노출합니다.
  * 설문 완료 화면의 획득 보상액 및 트래킹이 동적으로 반영됩니다.

* **Chores**
  * 집계 로직이 개별 설문 금액을 반영하도록 개선되어 총 프로모션 합계가 정확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->