### PR TITLE
[OMF-304] 선택 판정 기준을 content에서 optionId로 변경해 동시 선택 버그 해결

### DIFF
--- a/src/features/create-survey/components/bottomSheet/QuestionSelectionBottomSheet.tsx
+++ b/src/features/create-survey/components/bottomSheet/QuestionSelectionBottomSheet.tsx
@@ -24,20 +24,24 @@ export const QuestionSelectionBottomSheet = ({
 	}, [state.survey.question, questionId]);
 
 	const currentOptions = question?.option ?? [];
+	const trimmedSelection = selection.trim();
+	const hasDuplicateOption = currentOptions.some(
+		(option) => option.content === trimmedSelection,
+	);
 
 	const handleSelectionChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		setSelection(e.target.value);
 	};
 
 	const handleConfirm = () => {
-		if (selection.trim() && question) {
+		if (trimmedSelection && question && !hasDuplicateOption) {
 			updateQuestion(questionId, {
 				option: [
 					...currentOptions,
 					{
 						optionId: null,
 						order: currentOptions.length + 1,
-						content: selection.trim(),
+						content: trimmedSelection,
 						nextQuestionId: null,
 					},
 				],
@@ -64,7 +68,7 @@ export const QuestionSelectionBottomSheet = ({
 				<BottomSheet.CTA
 					color="primary"
 					variant="fill"
-					disabled={!selection.trim()}
+					disabled={!trimmedSelection || hasDuplicateOption}
 					onClick={handleConfirm}
 					style={
 						{ "--button-background-color": "#15c67f" } as React.CSSProperties

--- a/src/features/survey/pages/SingleChoice.tsx
+++ b/src/features/survey/pages/SingleChoice.tsx
@@ -108,10 +108,21 @@ export const SurveySingleChoice = () => {
 			return;
 		}
 
-		const matched = regularOptions.find(
-			(option) => option.content === currentAnswer,
-		);
-		setSelectedOptionId(matched?.optionId ?? null);
+		setSelectedOptionId((prev) => {
+			if (prev !== null) {
+				const previousOption = regularOptions.find(
+					(option) => option.optionId === prev,
+				);
+				if (previousOption?.content === currentAnswer) {
+					return prev;
+				}
+			}
+
+			const matched = regularOptions.find(
+				(option) => option.content === currentAnswer,
+			);
+			return matched?.optionId ?? null;
+		});
 	}, [currentAnswer, regularOptions]);
 
 	const hasCustomInput =

--- a/src/features/survey/pages/SingleChoice.tsx
+++ b/src/features/survey/pages/SingleChoice.tsx
@@ -95,6 +95,25 @@ export const SurveySingleChoice = () => {
 		[currentQuestion?.options],
 	);
 
+	const [selectedOptionId, setSelectedOptionId] = useState<number | null>(null);
+
+	useEffect(() => {
+		if (!regularOptions.length) {
+			setSelectedOptionId(null);
+			return;
+		}
+
+		if (!currentAnswer) {
+			setSelectedOptionId(null);
+			return;
+		}
+
+		const matched = regularOptions.find(
+			(option) => option.content === currentAnswer,
+		);
+		setSelectedOptionId(matched?.optionId ?? null);
+	}, [currentAnswer, regularOptions]);
+
 	const hasCustomInput =
 		currentQuestion?.hasCustomInput === true ||
 		currentQuestion?.options?.some(
@@ -106,26 +125,31 @@ export const SurveySingleChoice = () => {
 	}
 
 	// 일반 옵션 선택/해제 처리
-	const handleOptionSelect = (optionContent: string) => {
+	const handleOptionSelect = (optionId: number, optionContent: string) => {
 		if (isMultipleSelection) {
-			handleMultipleSelection(optionContent);
+			handleMultipleSelection(optionId, optionContent);
 		} else {
-			handleSingleSelection(optionContent);
+			handleSingleSelection(optionId, optionContent);
 		}
 	};
 
-	const handleSingleSelection = (optionContent: string) => {
-		if (currentAnswer === optionContent) {
+	const handleSingleSelection = (optionId: number, optionContent: string) => {
+		if (selectedOptionId === optionId) {
 			updateAnswer(currentQuestion.questionId, "");
+			setSelectedOptionId(null);
 		} else {
 			updateAnswer(currentQuestion.questionId, optionContent);
+			setSelectedOptionId(optionId);
 			if (isOtherOptionSelected) {
 				setCustomInputValue("");
 			}
 		}
 	};
 
-	const handleMultipleSelection = (optionContent: string) => {
+	const handleMultipleSelection = (
+		_optionId: number,
+		optionContent: string,
+	) => {
 		const isAlreadySelected = selectedAnswers.includes(optionContent);
 
 		if (isAlreadySelected) {
@@ -233,7 +257,9 @@ export const SurveySingleChoice = () => {
 				{regularOptions.length > 0 && (
 					<List role={isMultipleSelection ? "group" : "radiogroup"}>
 						{regularOptions.map((choice) => {
-							const isSelected = selectedAnswers.includes(choice.content);
+							const isSelected = isMultipleSelection
+								? selectedAnswers.includes(choice.content)
+								: selectedOptionId === choice.optionId;
 							const isDisabled =
 								isMultipleSelection &&
 								!isSelected &&
@@ -245,7 +271,8 @@ export const SurveySingleChoice = () => {
 									role={isMultipleSelection ? "checkbox" : "radio"}
 									aria-checked={isSelected}
 									onClick={() =>
-										!isDisabled && handleOptionSelect(choice.content)
+										!isDisabled &&
+										handleOptionSelect(choice.optionId, choice.content)
 									}
 									contents={
 										<ListRow.Texts

--- a/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
+++ b/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
@@ -141,6 +141,7 @@ export const MultipleChoiceQuestion = ({
 
 	const handleOptionToggle = (optionId: number, optionContent: string) => {
 		const isSelected = selectedOptionIds.includes(optionId);
+		const otherAnswers = selectedAnswers.filter(isOtherOption);
 
 		if (isMultipleSelection) {
 			if (isSelected) {
@@ -155,9 +156,10 @@ export const MultipleChoiceQuestion = ({
 							option !== undefined,
 					)
 					.map((option) => option.content);
+				const mergedAnswers = [...newAnswers, ...otherAnswers];
 				onAnswerChange(
 					question.questionId,
-					newAnswers.length > 0 ? joinAnswers(newAnswers) : "",
+					mergedAnswers.length > 0 ? joinAnswers(mergedAnswers) : "",
 				);
 
 				// 기타 옵션 해제 시 입력값 초기화
@@ -180,7 +182,7 @@ export const MultipleChoiceQuestion = ({
 					// 입력 필드가 즉시 표시되도록 입력값 초기화
 					setCustomInputValue("");
 				} else {
-					// 일반 옵션 선택 시 기존 답변 유지 (기타 답변 제외)
+					// 일반 옵션 선택 시 기존 기타 답변도 함께 유지
 					const nextSelectedIds = [...selectedOptionIds, optionId];
 					setSelectedOptionIds(nextSelectedIds);
 					const newAnswers = nextSelectedIds
@@ -192,7 +194,8 @@ export const MultipleChoiceQuestion = ({
 								option !== undefined,
 						)
 						.map((option) => option.content);
-					onAnswerChange(question.questionId, joinAnswers(newAnswers));
+					const mergedAnswers = [...newAnswers, ...otherAnswers];
+					onAnswerChange(question.questionId, joinAnswers(mergedAnswers));
 				}
 			}
 		} else {

--- a/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
+++ b/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
@@ -115,21 +115,40 @@ export const MultipleChoiceQuestion = ({
 			return;
 		}
 
-		const nextSelectedIds: number[] = [];
-		const usedIndexes = new Set<number>();
+		setSelectedOptionIds((prev) => {
+			const nextSelectedIds: number[] = [];
+			const usedOptionIds = new Set<number>();
 
-		selectedAnswers.forEach((answerText) => {
-			const idx = regularOptions.findIndex(
-				(option, index) =>
-					!usedIndexes.has(index) && option.content === answerText,
-			);
-			if (idx >= 0) {
-				usedIndexes.add(idx);
-				nextSelectedIds.push(regularOptions[idx].optionId);
-			}
+			selectedAnswers.forEach((answerText) => {
+				const previousMatchId = prev.find((optionId) => {
+					if (usedOptionIds.has(optionId)) {
+						return false;
+					}
+					const option = regularOptions.find(
+						(item) => item.optionId === optionId,
+					);
+					return option?.content === answerText;
+				});
+
+				if (previousMatchId !== undefined) {
+					usedOptionIds.add(previousMatchId);
+					nextSelectedIds.push(previousMatchId);
+					return;
+				}
+
+				const nextMatch = regularOptions.find(
+					(option) =>
+						!usedOptionIds.has(option.optionId) &&
+						option.content === answerText,
+				);
+				if (nextMatch) {
+					usedOptionIds.add(nextMatch.optionId);
+					nextSelectedIds.push(nextMatch.optionId);
+				}
+			});
+
+			return nextSelectedIds;
 		});
-
-		setSelectedOptionIds(nextSelectedIds);
 	}, [regularOptions, selectedAnswers]);
 
 	// hasCustomInput 확인

--- a/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
+++ b/src/features/survey/pages/components/MultipleChoiceQuestion.tsx
@@ -107,6 +107,31 @@ export const MultipleChoiceQuestion = ({
 		);
 	}, [question.options]);
 
+	const [selectedOptionIds, setSelectedOptionIds] = useState<number[]>([]);
+
+	useEffect(() => {
+		if (!regularOptions.length) {
+			setSelectedOptionIds([]);
+			return;
+		}
+
+		const nextSelectedIds: number[] = [];
+		const usedIndexes = new Set<number>();
+
+		selectedAnswers.forEach((answerText) => {
+			const idx = regularOptions.findIndex(
+				(option, index) =>
+					!usedIndexes.has(index) && option.content === answerText,
+			);
+			if (idx >= 0) {
+				usedIndexes.add(idx);
+				nextSelectedIds.push(regularOptions[idx].optionId);
+			}
+		});
+
+		setSelectedOptionIds(nextSelectedIds);
+	}, [regularOptions, selectedAnswers]);
+
 	// hasCustomInput 확인
 	const hasCustomInput =
 		question.hasCustomInput === true ||
@@ -114,19 +139,22 @@ export const MultipleChoiceQuestion = ({
 			(option) => option.content === OTHER_OPTION_PREFIX,
 		);
 
-	const handleOptionToggle = (optionContent: string) => {
-		const isSelected = selectedAnswers.some(
-			(answer) =>
-				answer === optionContent || answer.startsWith(`${optionContent}:`),
-		);
+	const handleOptionToggle = (optionId: number, optionContent: string) => {
+		const isSelected = selectedOptionIds.includes(optionId);
 
 		if (isMultipleSelection) {
 			if (isSelected) {
-				// 선택 해제
-				const newAnswers = selectedAnswers.filter(
-					(answer) =>
-						answer !== optionContent && !answer.startsWith(`${optionContent}:`),
+				const nextSelectedIds = selectedOptionIds.filter(
+					(id) => id !== optionId,
 				);
+				setSelectedOptionIds(nextSelectedIds);
+				const newAnswers = nextSelectedIds
+					.map((id) => regularOptions.find((option) => option.optionId === id))
+					.filter(
+						(option): option is (typeof regularOptions)[number] =>
+							option !== undefined,
+					)
+					.map((option) => option.content);
 				onAnswerChange(
 					question.questionId,
 					newAnswers.length > 0 ? joinAnswers(newAnswers) : "",
@@ -138,7 +166,7 @@ export const MultipleChoiceQuestion = ({
 				}
 			} else {
 				// 선택 추가
-				if (selectedAnswers.length >= maxChoice) {
+				if (selectedOptionIds.length >= maxChoice) {
 					return; // 최대 선택 개수 초과
 				}
 
@@ -152,24 +180,37 @@ export const MultipleChoiceQuestion = ({
 					// 입력 필드가 즉시 표시되도록 입력값 초기화
 					setCustomInputValue("");
 				} else {
-					// 일반 옵션 선택 시 기존 답변 유지 (기타 답변 포함)
-					const newAnswers = [...selectedAnswers, optionContent];
+					// 일반 옵션 선택 시 기존 답변 유지 (기타 답변 제외)
+					const nextSelectedIds = [...selectedOptionIds, optionId];
+					setSelectedOptionIds(nextSelectedIds);
+					const newAnswers = nextSelectedIds
+						.map((id) =>
+							regularOptions.find((option) => option.optionId === id),
+						)
+						.filter(
+							(option): option is (typeof regularOptions)[number] =>
+								option !== undefined,
+						)
+						.map((option) => option.content);
 					onAnswerChange(question.questionId, joinAnswers(newAnswers));
 				}
 			}
 		} else {
 			// 단일 선택
 			if (isSelected) {
+				setSelectedOptionIds([]);
 				onAnswerChange(question.questionId, "");
 				if (optionContent === OTHER_OPTION_PREFIX) {
 					setCustomInputValue("");
 				}
 			} else {
 				if (optionContent === OTHER_OPTION_PREFIX) {
+					setSelectedOptionIds([]);
 					onAnswerChange(question.questionId, OTHER_OPTION_PREFIX);
 					// 입력 필드가 즉시 표시되도록 입력값 초기화
 					setCustomInputValue("");
 				} else {
+					setSelectedOptionIds([optionId]);
 					onAnswerChange(question.questionId, optionContent);
 				}
 			}
@@ -273,11 +314,7 @@ export const MultipleChoiceQuestion = ({
 					{regularOptions.length > 0 && (
 						<List>
 							{regularOptions.map((option) => {
-								const isSelected = selectedAnswers.some(
-									(answer) =>
-										answer === option.content ||
-										answer.startsWith(`${option.content}:`),
-								);
+								const isSelected = selectedOptionIds.includes(option.optionId);
 								return (
 									<div key={option.optionId}>
 										<ListRow
@@ -297,7 +334,9 @@ export const MultipleChoiceQuestion = ({
 													aria-hidden={true}
 												/>
 											}
-											onClick={() => handleOptionToggle(option.content)}
+											onClick={() =>
+												handleOptionToggle(option.optionId, option.content)
+											}
 										/>
 										{option.imageUrl && (
 											<div className="px-6 pt-2 pb-3">


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 선택 판정 기준을 content에서 optionId로 변경해 동시 선택 버그 해결


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-304


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 설문에 동일 내용의 선택지가 중복으로 추가되는 문제를 방지했습니다.
  * 선택지 추가 버튼이 빈 입력이나 중복 입력일 때 비활성화되도록 개선했습니다.

* **개선 사항**
  * 단일 선택 및 다중 선택의 선택/해제 동작이 더 일관되고 안정적으로 동작하도록 개선했습니다.
  * 다중 선택에서 최대 선택 수 제한이 안정적으로 적용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->