### PR TITLE
[OMF-310] 빈 섹션과 1섹션 무문항 설문의 참여·다음 진행 보정

### DIFF
--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -76,6 +76,13 @@ export function useSectionBasedSurveyController() {
 	);
 
 	const isLastSection = actualNextSection === 0;
+
+	const canSkipEmptySectionForward =
+		questions.length === 0 &&
+		!isLastSection &&
+		actualNextSection > 0 &&
+		actualNextSection !== currentSection;
+
 	const [previousAnswers, setPreviousAnswers] = useState<
 		Record<number, string>
 	>(locationState?.previousAnswers ?? {});
@@ -246,7 +253,8 @@ export function useSectionBasedSurveyController() {
 	const handleNext = async () => {
 		if (!surveyId) return;
 		if (sectionActionInFlightRef.current) return;
-		if (isPending || questions.length === 0) return;
+		if (isPending) return;
+		if (questions.length === 0 && !canSkipEmptySectionForward) return;
 
 		pushGtmEvent({
 			event: "survey_progress_button_click",
@@ -328,7 +336,8 @@ export function useSectionBasedSurveyController() {
 
 	const handleSubmitClick = async () => {
 		if (sectionActionInFlightRef.current) return;
-		if (isPending || questions.length === 0) return;
+		if (isPending) return;
+		if (questions.length === 0 && !isLastSection) return;
 
 		if (surveyId) {
 			pushGtmEvent({
@@ -366,6 +375,7 @@ export function useSectionBasedSurveyController() {
 	return {
 		headerTitleText,
 		headerSubtitleText,
+		canSkipEmptySectionForward,
 		questions,
 		answers,
 		updateAnswer,

--- a/src/features/survey/hooks/useSurveyQuestions.ts
+++ b/src/features/survey/hooks/useSurveyQuestions.ts
@@ -1,5 +1,5 @@
 import {
-	getSurveyQuestions,
+	getSurveyQuestionsForSurveyIntro,
 	type TransformedSurveyQuestion,
 } from "@features/survey/service/surveyParticipation";
 import { useQuery } from "@tanstack/react-query";
@@ -20,7 +20,7 @@ export const useSurveyQuestions = (
 			if (surveyId === undefined || surveyId === null) {
 				throw new Error("surveyId가 필요합니다.");
 			}
-			return getSurveyQuestions({ surveyId });
+			return getSurveyQuestionsForSurveyIntro(surveyId);
 		},
 		enabled: Boolean(surveyId) && enabled,
 		retry: false,

--- a/src/features/survey/lib/calculateNextSection.ts
+++ b/src/features/survey/lib/calculateNextSection.ts
@@ -31,5 +31,22 @@ export function calculateNextSection(
 		}
 	}
 
+	if (questions.length === 0) {
+		if (
+			nextSectionFromApi != null &&
+			nextSectionFromApi > 0 &&
+			nextSectionFromApi !== currentSection
+		) {
+			return nextSectionFromApi;
+		}
+		if (nextSectionFromApi === currentSection) {
+			return currentSection + 1;
+		}
+		if (nextSectionFromApi === 0) {
+			return currentSection + 1;
+		}
+		return nextSectionFromApi ?? currentSection + 1;
+	}
+
 	return nextSectionFromApi ?? currentSection + 1;
 }

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -31,6 +31,7 @@ export const SectionBasedSurvey = () => {
 		submitting,
 		nextLoading,
 		isPending,
+		canSkipEmptySectionForward,
 	} = useSectionBasedSurveyController();
 
 	return (
@@ -101,7 +102,7 @@ export const SectionBasedSurvey = () => {
 				rightButton={
 					isLastSection ? (
 						<CTAButton
-							disabled={submitting || isPending || questions.length === 0}
+							disabled={submitting || isPending}
 							loading={submitting}
 							onClick={handleSubmitClick}
 						>
@@ -109,7 +110,11 @@ export const SectionBasedSurvey = () => {
 						</CTAButton>
 					) : (
 						<CTAButton
-							disabled={nextLoading || isPending || questions.length === 0}
+							disabled={
+								nextLoading ||
+								isPending ||
+								(questions.length === 0 && !canSkipEmptySectionForward)
+							}
 							loading={nextLoading}
 							onClick={handleNext}
 						>

--- a/src/features/survey/service/surveyParticipation/api.ts
+++ b/src/features/survey/service/surveyParticipation/api.ts
@@ -124,6 +124,43 @@ export const getSurveyQuestions = async (
 	};
 };
 
+export const getSurveyQuestionsForSurveyIntro = async (
+	surveyId: number,
+): Promise<{
+	info: TransformedSurveyQuestion[];
+	sectionTitle?: string;
+	sectionDescription?: string;
+	currSection?: number;
+	nextSection?: number;
+}> => {
+	const section1 = await getSurveyQuestions({ surveyId, section: 1 });
+	if (section1.info.length > 0) {
+		return section1;
+	}
+
+	const sectionsToTry = new Set<number>();
+	if (
+		section1.nextSection != null &&
+		section1.nextSection > 0 &&
+		section1.nextSection !== 1
+	) {
+		sectionsToTry.add(section1.nextSection);
+	}
+	for (let s = 2; s <= 30; s += 1) {
+		sectionsToTry.add(s);
+	}
+
+	for (const section of sectionsToTry) {
+		if (section <= 1) continue;
+		const res = await getSurveyQuestions({ surveyId, section });
+		if (res.info.length > 0) {
+			return res;
+		}
+	}
+
+	return section1;
+};
+
 // 설문 정보와 문항 정보를 함께 조회 (하위 호환성 유지)
 export const getSurveyParticipation = async (
 	params: GetSurveyParticipationParams,


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

-  빈 섹션과 1섹션 무문항 설문의 참여·다음 진행 보정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-310


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  


## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


Uploading 화면 기록 2026-04-18 오후 4.16.50.mov…




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 빈 설문 섹션을 건너뛸 수 있는 기능 추가

* **개선 사항**
  * "다음" 및 "제출" 버튼의 활성화 상태 로직 개선
  * 설문 시작 시 질문이 있는 첫 섹션을 자동으로 찾아 표시하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->