### PR TITLE
[OMF-309] 섹션 분기 뒤 이전 이동 시 응답 섞임 문제 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.claude
+.mcp.json
 
 .granite
 onsurvey.ait

--- a/src/features/survey/hooks/useCompleteSurvey.ts
+++ b/src/features/survey/hooks/useCompleteSurvey.ts
@@ -5,8 +5,17 @@ export const useCompleteSurvey = () => {
 	const queryClient = useQueryClient();
 
 	return useMutation({
-		mutationFn: ({ surveyId }: { surveyId: number }) =>
-			completeSurvey(surveyId),
+		mutationFn: ({
+			surveyId,
+			visitedSections,
+		}: {
+			surveyId: number;
+			visitedSections?: number[];
+		}) =>
+			completeSurvey(
+				surveyId,
+				visitedSections?.length ? { visitedSections } : undefined,
+			),
 		onSuccess: (_, variables) => {
 			queryClient.invalidateQueries({
 				queryKey: ["surveyInfo", variables.surveyId],

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -218,10 +218,52 @@ export function useSectionBasedSurveyController() {
 		}
 	};
 
+	/** 분기 경로 */
+	const buildVisitedSectionsPayload = (): number[] => {
+		const path: number[] = [];
+		for (const s of sectionHistory) {
+			if (path.length === 0 || path[path.length - 1] !== s) {
+				path.push(s);
+			}
+		}
+		if (path.length === 0 || path[path.length - 1] !== currentSection) {
+			path.push(currentSection);
+		}
+		return path;
+	};
+
+	const clearAnswersForCurrentSection = () => {
+		if (questions.length === 0) return;
+		const ids = questions.map((q) => q.questionId);
+		const nextAnswers = { ...answersRef.current };
+		for (const id of ids) {
+			delete nextAnswers[id];
+		}
+		answersRef.current = nextAnswers;
+		setAnswers(nextAnswers);
+		setPreviousAnswers((p) => {
+			const cp = { ...p };
+			for (const id of ids) {
+				delete cp[id];
+			}
+			return cp;
+		});
+		setQuestionErrors((p) => {
+			const cp = { ...p };
+			for (const id of ids) {
+				delete cp[id];
+			}
+			return cp;
+		});
+	};
+
 	const handlePrev = () => {
 		if (currentSection === 1) {
 			navigate(`/survey?surveyId=${surveyId}`, { replace: true });
 		} else {
+			// 이전으로 가면서 떠나는 섹션의 로컬 응답을 제거해 분기 변경 시 응답이 섞이지 않게 함
+			clearAnswersForCurrentSection();
+
 			const currentIndex = sectionHistory.lastIndexOf(currentSection);
 			let prevSection: number;
 			let newHistory: number[];
@@ -304,7 +346,9 @@ export function useSectionBasedSurveyController() {
 	const handleSubmit = async () => {
 		if (!surveyId) return;
 
-		await completeSurveyMutation({ surveyId });
+		const visitedSections = buildVisitedSectionsPayload();
+
+		await completeSurveyMutation({ surveyId, visitedSections });
 
 		let surveyInfo: Awaited<ReturnType<typeof getSurveyInfo>> | undefined;
 		try {

--- a/src/features/survey/service/surveyParticipation/api.ts
+++ b/src/features/survey/service/surveyParticipation/api.ts
@@ -204,11 +204,24 @@ export const submitScreeningResponse = async (
 	});
 };
 
+/** 완료 시 서버가 최종 방문 경로만 반영하도록 방문 섹션 목록을 전달할 때 사용 */
+export type CompleteSurveyRequestBody = {
+	visitedSections?: number[];
+};
+
 //설문 완료 처리
-export const completeSurvey = async (surveyId: number): Promise<boolean> => {
-	const { data } = await api.post<{ result: boolean }, undefined>(
-		`/v1/survey-participation/surveys/${surveyId}/complete`,
-	);
+export const completeSurvey = async (
+	surveyId: number,
+	body?: CompleteSurveyRequestBody,
+): Promise<boolean> => {
+	const url = `/v1/survey-participation/surveys/${surveyId}/complete`;
+	if (import.meta.env.DEV) {
+		console.log("[completeSurvey] POST", url, body ?? {});
+	}
+	const { data } = await api.post<
+		{ result: boolean },
+		CompleteSurveyRequestBody
+	>(url, body);
 	return data.result ?? false;
 };
 

--- a/src/features/survey/service/surveyParticipation/api.ts
+++ b/src/features/survey/service/surveyParticipation/api.ts
@@ -215,9 +215,6 @@ export const completeSurvey = async (
 	body?: CompleteSurveyRequestBody,
 ): Promise<boolean> => {
 	const url = `/v1/survey-participation/surveys/${surveyId}/complete`;
-	if (import.meta.env.DEV) {
-		console.log("[completeSurvey] POST", url, body ?? {});
-	}
 	const { data } = await api.post<
 		{ result: boolean },
 		CompleteSurveyRequestBody


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 섹션 분기 뒤 이전 이동 시 응답 섞임 문제 수정


## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-309


 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [ ] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  



## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 설문 완료 시 사용자가 방문한 섹션 목록을 자동 수집해 전송하도록 확장되어 더 정확한 완료 기록 확보

* **버그 수정 / 동작 개선**
  * 섹션 이동 시 해당 섹션의 응답 및 오류 상태를 초기화해 분기 탐색 중 데이터 유실/혼합 방지

* **기타(관리)**
  * 개발환경 관련 불필요 파일들을 무시하도록 설정 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->