### PR TITLE
[OMF-314] 타이틀 전용 문항(TITLE) 타입 추가 및 프로모션 표기 오류 수정

### DIFF
--- a/src/features/create-survey/hooks/useQuestionByType.ts
+++ b/src/features/create-survey/hooks/useQuestionByType.ts
@@ -10,6 +10,7 @@ import {
 	isNumberQuestion,
 	isRatingQuestion,
 	isShortAnswerQuestion,
+	isTitleQuestion,
 	type LongAnswerQuestion,
 	type MultipleChoiceQuestion,
 	type NPSQuestion,
@@ -17,6 +18,7 @@ import {
 	type QuestionType,
 	type RatingQuestion,
 	type ShortAnswerQuestion,
+	type TitleQuestion,
 } from "@shared/types/survey";
 import { useSearchParams } from "react-router-dom";
 
@@ -29,6 +31,7 @@ type QuestionTypeMap = {
 	number: NumberQuestion;
 	multipleChoice: MultipleChoiceQuestion;
 	image: ImageQuestion;
+	title: TitleQuestion;
 };
 
 const typeGuardMap = {
@@ -40,6 +43,7 @@ const typeGuardMap = {
 	number: isNumberQuestion,
 	multipleChoice: isMultipleChoiceQuestion,
 	image: isImageQuestion,
+	title: isTitleQuestion,
 } as const;
 
 export const useQuestionByType = <T extends QuestionType>(type: T) => {

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -26,6 +26,7 @@ export interface SectionBasedSurveyState {
 	surveyDescription?: string;
 	source?: "main" | "quiz" | "after_complete";
 	sectionHistory?: number[];
+	price?: number;
 }
 
 export function useSectionBasedSurveyController() {
@@ -266,7 +267,10 @@ export function useSectionBasedSurveyController() {
 
 	const handlePrev = () => {
 		if (currentSection === 1) {
-			navigate(`/survey?surveyId=${surveyId}`, { replace: true });
+			navigate(`/survey?surveyId=${surveyId}`, {
+				replace: true,
+				state: { surveyId, price: locationState?.price },
+			});
 		} else {
 			// 이전으로 가면서 떠나는 섹션의 로컬 응답을 제거해 분기 변경 시 응답이 섞이지 않게 함
 			clearAnswersForCurrentSection();

--- a/src/features/survey/hooks/useSurveyRouteParams.ts
+++ b/src/features/survey/hooks/useSurveyRouteParams.ts
@@ -7,6 +7,7 @@ export interface SurveyLocationState {
 	surveyId?: string;
 	source?: "main" | "quiz" | "after_complete";
 	quiz_id?: number;
+	price?: number;
 }
 
 export const useSurveyRouteParams = () => {
@@ -26,10 +27,13 @@ export const useSurveyRouteParams = () => {
 		return Number.isNaN(parsed) ? null : parsed;
 	}, [surveyId]);
 
+	const priceFromState = locationState?.price ?? locationState?.survey?.price;
+
 	return {
 		surveyId,
 		numericSurveyId,
 		surveyFromState,
 		locationState,
+		priceFromState,
 	};
 };

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -43,8 +43,13 @@ export const Survey = () => {
 	});
 	const [hasAuthToken, setHasAuthToken] = useState<boolean | null>(null);
 
-	const { surveyId, numericSurveyId, surveyFromState, locationState } =
-		useSurveyRouteParams();
+	const {
+		surveyId,
+		numericSurveyId,
+		surveyFromState,
+		locationState,
+		priceFromState,
+	} = useSurveyRouteParams();
 
 	useEffect(() => {
 		let isMounted = true;
@@ -220,6 +225,7 @@ export const Survey = () => {
 				surveyTitle: surveyTitle ?? "",
 				surveyDescription: surveyDescription ?? "",
 				source,
+				price: surveyBasicInfoData?.price ?? priceFromState,
 			},
 		});
 	};
@@ -299,7 +305,7 @@ export const Survey = () => {
 						isFree={isFree}
 						questionCount={sortedQuestions.length}
 						remainingTimeText={remainingTimeText}
-						price={surveyBasicInfoData?.price ?? surveyFromState?.price}
+						price={surveyBasicInfoData?.price ?? priceFromState}
 					/>
 					<div className="px-4 mt-4">
 						<Button

--- a/src/features/survey/pages/components/QuestionRenderer.tsx
+++ b/src/features/survey/pages/components/QuestionRenderer.tsx
@@ -7,6 +7,7 @@ import { NPSQuestion } from "./NPSQuestion";
 import { NumberQuestion } from "./NumberQuestion";
 import { RatingQuestion } from "./RatingQuestion";
 import { ShortAnswerQuestion } from "./ShortAnswerQuestion";
+import { TitleQuestion } from "./TitleQuestion";
 
 interface QuestionRendererProps {
 	question: TransformedSurveyQuestion;
@@ -58,6 +59,8 @@ export const QuestionRenderer = ({
 			return <NPSQuestion {...commonProps} />;
 		case "image":
 			return <ImageQuestion {...commonProps} />;
+		case "title":
+			return <TitleQuestion {...commonProps} />;
 		default:
 			return null;
 	}

--- a/src/features/survey/pages/components/TitleQuestion.tsx
+++ b/src/features/survey/pages/components/TitleQuestion.tsx
@@ -1,0 +1,45 @@
+import { TextWithLinks } from "@features/survey/components/TextWithLinks";
+import type { TransformedSurveyQuestion } from "@features/survey/service/surveyParticipation";
+import { adaptive } from "@toss/tds-colors";
+import { ListHeader, Spacing } from "@toss/tds-mobile";
+
+interface TitleQuestionProps {
+	question: TransformedSurveyQuestion;
+	answer?: string;
+	onAnswerChange: (questionId: number, answer: string) => void;
+	error?: boolean;
+	errorMessage?: string;
+	isExpanded?: boolean;
+	onToggleExpand?: () => void;
+}
+
+export const TitleQuestion = ({ question }: TitleQuestionProps) => {
+	return (
+		<>
+			<ListHeader
+				descriptionPosition="bottom"
+				title={
+					<ListHeader.TitleParagraph
+						color={adaptive.grey800}
+						fontWeight="bold"
+						typography="t4"
+					>
+						<TextWithLinks
+							text={question.title}
+							variant="inline"
+							inheritLinkSize
+						/>
+					</ListHeader.TitleParagraph>
+				}
+				description={
+					question.description ? (
+						<ListHeader.DescriptionParagraph>
+							<TextWithLinks text={question.description} variant="inline" />
+						</ListHeader.DescriptionParagraph>
+					) : undefined
+				}
+			/>
+			<Spacing size={32} />
+		</>
+	);
+};

--- a/src/features/survey/pages/components/index.ts
+++ b/src/features/survey/pages/components/index.ts
@@ -7,3 +7,4 @@ export * from "./NumberQuestion";
 export * from "./QuestionRenderer";
 export * from "./RatingQuestion";
 export * from "./ShortAnswerQuestion";
+export * from "./TitleQuestion";

--- a/src/features/survey/service/surveyParticipation/types.ts
+++ b/src/features/survey/service/surveyParticipation/types.ts
@@ -9,7 +9,8 @@ export type BackendQuestionType =
 	| "LONG_ANSWER"
 	| "DATE"
 	| "NUMBER"
-	| "IMAGE"; // 이미지 전용 문항
+	| "IMAGE" // 이미지 전용 문항
+	| "TITLE"; // 타이틀 전용 문항
 
 // 백엔드 응답의 옵션 타입
 export interface BackendOption {
@@ -69,13 +70,19 @@ export type OtherQuestion = BaseSurveyParticipationQuestion & {
 	questionType: "NPS" | "SHORT_ANSWER" | "LONG_ANSWER" | "NUMBER";
 };
 
+// 타이틀 전용 문항 (제목·설명만)
+export type TitleQuestion = BaseSurveyParticipationQuestion & {
+	questionType: "TITLE";
+};
+
 // 모든 문항 타입의 유니온
 export type SurveyParticipationQuestion =
 	| ChoiceQuestion
 	| DateQuestion
 	| RatingQuestion
 	| ImageQuestion
-	| OtherQuestion;
+	| OtherQuestion
+	| TitleQuestion;
 
 export const mapBackendQuestionType = (
 	backendType: BackendQuestionType | string,
@@ -91,6 +98,7 @@ export const mapBackendQuestionType = (
 		DATE: "date",
 		NUMBER: "number",
 		IMAGE: "image",
+		TITLE: "title",
 	};
 	const key = String(backendType ?? "")
 		.trim()

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -10,4 +10,5 @@ export const QUESTION_TYPE_ROUTES: Record<QuestionType, string> = {
 	date: "/createForm/date",
 	number: "/createForm/number",
 	image: "/createForm/image",
+	title: "/createForm/image",
 };

--- a/src/shared/lib/questionFactory.ts
+++ b/src/shared/lib/questionFactory.ts
@@ -29,6 +29,7 @@ export const getQuestionTypeLabel = (type: Question["type"]): string => {
 		date: "날짜",
 		number: "숫자",
 		image: "이미지",
+		title: "타이틀",
 	};
 	return typeLabels[type];
 };

--- a/src/shared/lib/questionRoute.ts
+++ b/src/shared/lib/questionRoute.ts
@@ -14,6 +14,7 @@ export const getQuestionTypeRoute = (
 		date: "/survey/date",
 		number: "/survey/number",
 		image: "/survey/shortAnswer", // 이미지 문항은 섹션 설문에서만 표시
+		title: "/survey/shortAnswer", // 타이틀 문항은 섹션 설문에서만 표시
 	};
 	return routes[type] || "/survey/shortAnswer";
 };
@@ -29,6 +30,7 @@ export const getQuestionResultRoute = (type: QuestionType): string => {
 		date: "/result/date",
 		number: "/result/number",
 		image: "/result/shortAnswer", // 이미지 문항 결과는 단답형과 동일 경로
+		title: "/result/shortAnswer", // 타이틀 문항 결과는 단답형과 동일 경로
 	};
 	return routes[type] || "/result/shortAnswer";
 };

--- a/src/shared/lib/questionTypeUtils.ts
+++ b/src/shared/lib/questionTypeUtils.ts
@@ -10,10 +10,19 @@ export const mapQuestionTypeToServerFormat = (
 	| "LONG"
 	| "DATE"
 	| "NUMBER"
-	| "IMAGE" => {
+	| "IMAGE"
+	| "TITLE" => {
 	const typeMap: Record<
 		Question["type"],
-		"CHOICE" | "RATING" | "NPS" | "SHORT" | "LONG" | "DATE" | "NUMBER" | "IMAGE"
+		| "CHOICE"
+		| "RATING"
+		| "NPS"
+		| "SHORT"
+		| "LONG"
+		| "DATE"
+		| "NUMBER"
+		| "IMAGE"
+		| "TITLE"
 	> = {
 		multipleChoice: "CHOICE",
 		rating: "RATING",
@@ -23,6 +32,7 @@ export const mapQuestionTypeToServerFormat = (
 		date: "DATE",
 		number: "NUMBER",
 		image: "IMAGE",
+		title: "TITLE",
 	};
 	return typeMap[type];
 };

--- a/src/shared/lib/surveySubmission.ts
+++ b/src/shared/lib/surveySubmission.ts
@@ -12,7 +12,7 @@ interface BuildSectionAnswersPayloadParams {
 /** 참여 화면에서 사용자 입력 필드가 없어 응답을 제출하지 않는 문항 */
 export const isNonAnswerableParticipationQuestion = (
 	question: Pick<TransformedSurveyQuestion, "type">,
-): boolean => question.type === "image";
+): boolean => question.type === "image" || question.type === "title";
 
 /**
  * 현재 섹션의 답변을 제출 형식으로 변환

--- a/src/shared/types/survey.ts
+++ b/src/shared/types/survey.ts
@@ -8,7 +8,8 @@ export type QuestionType =
 	| "longAnswer" // 장문형
 	| "date" // 날짜 (ex: 2025-10-26)
 	| "number" // 숫자형 (1~100)
-	| "image"; // 이미지 전용 (타이틀·보조설명·이미지만 표시)
+	| "image" // 이미지 전용 (타이틀·보조설명·이미지만 표시)
+	| "title"; // 타이틀 전용 (제목·설명만 표시)
 
 export interface BaseQuestion {
 	surveyId: number;
@@ -77,6 +78,11 @@ export interface ImageQuestion extends BaseQuestion {
 	imageUrl: string;
 }
 
+// 타이틀 전용 문항 (제목·설명만 표시)
+export interface TitleQuestion extends BaseQuestion {
+	type: "title";
+}
+
 // 모든 문항 타입의 유니온
 export type Question =
 	| MultipleChoiceQuestion
@@ -86,7 +92,8 @@ export type Question =
 	| LongAnswerQuestion
 	| DateQuestion
 	| NumberQuestion
-	| ImageQuestion;
+	| ImageQuestion
+	| TitleQuestion;
 
 // 문항 정보 구조
 export interface QuestionInfo {
@@ -242,4 +249,10 @@ export const isImageQuestion = (
 	question: Question | undefined,
 ): question is ImageQuestion => {
 	return question?.type === "image";
+};
+
+export const isTitleQuestion = (
+	question: Question | undefined,
+): question is TitleQuestion => {
+	return question?.type === "title";
 };


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 타이틀 전용 문항(TITLE) 타입 추가
- 프로모션 표기 오류 수정

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-314

## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 설문에 새로운 "타이틀" 질문 유형이 추가되었습니다. 사용자는 이제 설문 구성에 제목과 설명을 포함한 타이틀 섹션을 추가할 수 있으며, 텍스트에 인라인 링크를 포함시킬 수 있습니다. 타이틀 섹션은 응답이 필요하지 않은 정보 표시 요소로 작동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->