### PR TITLE
[OMF-318] 링크로 서비스 접속시 UX 개선 및 버그 픽스

### DIFF
--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -20,33 +20,20 @@ export const Intro = () => {
 		const checkAuth = async () => {
 			try {
 				const memberInfo = await getMemberInfo();
-
-				// 자동 로그인 완료 시 user_info 이벤트 전송
 				void sendUserInfoEvent("Toss");
-
-				// isOnboardingCompleted 상태에 따라 분기
 				if (memberInfo.isOnboardingCompleted) {
-					// 원래 페이지로 돌아가거나 홈으로 이동
 					if (returnTo) {
-						navigate(returnTo.path, {
-							replace: true,
-							state: returnTo.state,
-						});
+						navigate(returnTo.path, { replace: true, state: returnTo.state });
 					} else {
-						navigate("/home", {
-							replace: true,
-							state: { isAutoLogin: true },
-						});
+						navigate("/home", { replace: true, state: { isAutoLogin: true } });
 					}
 				} else {
-					// 온보딩으로 이동 (returnTo 정보 전달)
 					navigate("/onboarding", {
 						replace: true,
 						state: returnTo ? { returnTo } : undefined,
 					});
 				}
 			} catch (error) {
-				// 인증 실패 (토큰 없거나 만료 등) 시에는 로그인 페이지 유지
 				console.error("자동 로그인 확인 실패:", error);
 			}
 		};
@@ -132,6 +119,7 @@ export const Intro = () => {
 				}
 				hideLine={true}
 			/>
+
 			<FixedBottomCTA
 				loading={false}
 				onClick={handleLogin}

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -192,6 +192,16 @@ export const Survey = () => {
 		surveyBasicInfoData,
 	]);
 
+	useEffect(() => {
+		if (!isClosed) return;
+		setErrorDialog({
+			open: true,
+			title: "마감된 설문입니다",
+			description: "참여 기간이 종료된 설문이에요.",
+			redirectTo: "/home",
+		});
+	}, [isClosed]);
+
 	const apiError = surveyBasicInfoError ?? surveyQuestionsError;
 
 	useEffect(() => {

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -146,15 +146,12 @@ export const Survey = () => {
 		);
 	}, [surveyQuestionsData?.info]);
 
-	const { getScreeningError, getAuthErrorFromException } = useSurveyAccessCheck(
-		{
-			surveyBasicInfoData: surveyBasicInfoData ?? null,
-			surveyId,
-			surveyFromState,
-			locationState,
-		},
-	);
-	const screeningError = getScreeningError();
+	const { getAuthErrorFromException } = useSurveyAccessCheck({
+		surveyBasicInfoData: surveyBasicInfoData ?? null,
+		surveyId,
+		surveyFromState,
+		locationState,
+	});
 	const isAccessChecking =
 		hasAuthToken === null ||
 		(Boolean(numericSurveyId) &&
@@ -164,12 +161,36 @@ export const Survey = () => {
 		sortedQuestions.length === 0 ||
 		!numericSurveyId ||
 		isAccessChecking ||
-		Boolean(screeningError);
+		Boolean(surveyBasicInfoData?.isScreenRequired) ||
+		Boolean(surveyBasicInfoData?.isScreened);
 
 	useEffect(() => {
-		if (!numericSurveyId || !screeningError) return;
-		setErrorDialog(screeningError);
-	}, [numericSurveyId, screeningError]);
+		if (!numericSurveyId || !surveyBasicInfoData || hasAuthToken !== true)
+			return;
+		if (isSurveyBasicInfoLoading || isSurveyBasicInfoFetching) return;
+
+		if (surveyBasicInfoData.isScreenRequired) {
+			navigate(`/oxScreening?surveyId=${numericSurveyId}`, { replace: true });
+			return;
+		}
+
+		if (surveyBasicInfoData.isScreened) {
+			setErrorDialog({
+				open: true,
+				title: "스크리닝 조건이 맞지 않습니다",
+				description:
+					"설정하신 스크리닝 조건에 맞지 않아 설문에 참여할 수 없어요.",
+				redirectTo: "/home",
+			});
+		}
+	}, [
+		hasAuthToken,
+		isSurveyBasicInfoFetching,
+		isSurveyBasicInfoLoading,
+		navigate,
+		numericSurveyId,
+		surveyBasicInfoData,
+	]);
 
 	const apiError = surveyBasicInfoError ?? surveyQuestionsError;
 
@@ -198,8 +219,16 @@ export const Survey = () => {
 
 	const handleStart = () => {
 		if (isStartDisabled) {
-			if (screeningError) {
-				setErrorDialog(screeningError);
+			if (surveyBasicInfoData?.isScreenRequired) {
+				navigate(`/oxScreening?surveyId=${numericSurveyId}`, { replace: true });
+			} else if (surveyBasicInfoData?.isScreened) {
+				setErrorDialog({
+					open: true,
+					title: "스크리닝 조건이 맞지 않습니다",
+					description:
+						"설정하신 스크리닝 조건에 맞지 않아 설문에 참여할 수 없어요.",
+					redirectTo: "/home",
+				});
 			}
 			return;
 		}


### PR DESCRIPTION
## 📌 주요 변경 사항
<!-- 이 PR에서 어떤 작업을 했는지 간단히 요약해주세요. -->

- 스크리닝 필요 시 모달 대신 스크리닝 페이지로 자동 이동
- 마감된 설문 접근 시 안내 모달 및 홈 이동 처리 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 번호를 연결해주세요. -->
Jira 링크: https://onsurvey.atlassian.net/browse/OMF-318
 
## ✅ 리뷰 요청 사항 (Need Review)
<!-- 아래 옵션 중 하나 이상을 선택해주세요. -->

- [x] 🙂 **크게 우려되는 사항은 없어요.** 가볍게 리뷰 부탁드려요.  

## 🎨 스크린샷 (선택)
<!-- 작업한 내용의 뷰를 첨부해주세요. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선사항
* 설문 스크리닝 접근 제한 로직 개선
* 스크리닝이 필요한 경우 사용자를 안내 페이지로 자동 이동
* 스크리닝 조건 미충족 시 명확한 오류 대화창 제공
* 종료된 설문 접근 시 명확한 오류 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->