### PR TITLE
[OMF-332] 인트로 설문 유입·open-stats 연동 및 섹션 설문 UX/분기 판정 개선

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"pullapi": "orval --config tools/orval.config.ts && biome check --write src/api"
 	},
 	"dependencies": {
-		"@apps-in-toss/web-framework": "2.0.5",
+		"@apps-in-toss/web-framework": "2.0.4",
 		"@emotion/react": "^11",
 		"@microsoft/clarity": "^1.0.2",
 		"@sentry/react": "^10.17.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
 		"pullapi": "orval --config tools/orval.config.ts && biome check --write src/api"
 	},
 	"dependencies": {
-		"@apps-in-toss/web-framework": "2.0.4",
+		"@apps-in-toss/web-framework": "2.0.5",
 		"@emotion/react": "^11",
 		"@microsoft/clarity": "^1.0.2",
 		"@sentry/react": "^10.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@apps-in-toss/web-framework':
-        specifier: 2.0.4
-        version: 2.0.4(ff0f2754757ec9b85c426f97bbe7019f)
+        specifier: 2.0.5
+        version: 2.0.5(ff0f2754757ec9b85c426f97bbe7019f)
       '@emotion/react':
         specifier: ^11
         version: 11.14.0(@types/react@18.3.27)(react@18.3.1)
@@ -37,7 +37,7 @@ importers:
         version: 2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@toss/tds-mobile-ait':
         specifier: ^2.3.0
-        version: 2.3.0(@apps-in-toss/web-framework@2.0.4(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.3.0(@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
         specifier: ^1.12.2
         version: 1.13.4
@@ -125,8 +125,8 @@ packages:
     resolution: {integrity: sha512-1no0CXOhPEeSCrGduT37KMmCqA6irhowXa0S7AaPHb4RQSHGioR3wvvD7HHBCaUriMYs0EvtqRJfOgYd0ycKlQ==}
     engines: {node: '>=24'}
 
-  '@apps-in-toss/analytics@2.0.4':
-    resolution: {integrity: sha512-0bv5cSaqoUFHc2wI3pclB0jBQSzmAmXisEFHclJNQ/3nDWEwRB3rbofz8vi9qMzir2cR7v2fKZ2oujwcX5gPRQ==}
+  '@apps-in-toss/analytics@2.0.5':
+    resolution: {integrity: sha512-9ZKIw8a6gVlO04TEO65FctmAjWgh9r1MfMru2X1iB57FcwknuYYLxT8rU1ANLebSBg19AZMWZKirsMKOVreqDQ==}
     peerDependencies:
       '@granite-js/native': '*'
       '@granite-js/react-native': '*'
@@ -135,14 +135,14 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/bridge-core@2.0.4':
-    resolution: {integrity: sha512-KaOiGjj+b4KwwSfN8vAFKaMcwsdDIHIB5cNJYSJ2gaL1/5wPpidSzd6mifOo7/a+f+MuoycfP6fmCuJCmf20AQ==}
+  '@apps-in-toss/bridge-core@2.0.5':
+    resolution: {integrity: sha512-NAq214QjHsEfLp2qZSOm7NOwafI9Uv12y1y3X6sHOLInfe38NkKUDmSjwfM1GwE4h4f5rF4HsXnNu/FUvC2jcg==}
 
-  '@apps-in-toss/cli@2.0.4':
-    resolution: {integrity: sha512-GyDMmT6R7b8PHrD7E8SbSUS6bvKtUacIF7REDBENBsOFndScA4XY5O3H6k3j9KtdsD1gq1UhP4nFqDQgkXs80g==}
+  '@apps-in-toss/cli@2.0.5':
+    resolution: {integrity: sha512-m0nXY2gxpd/IcT4mz3TIHzWVc10oU1CKIL2Ymmu50ivmlWeyaP43m0MifxqWq/tYyIc5w3e3v/wlJlb9PeXRwA==}
 
-  '@apps-in-toss/framework@2.0.4':
-    resolution: {integrity: sha512-7j2TSs3WIjE1N41BcbnRYsPYOOYGsutCPTz9Tg3Ihc263yLqCGUINdixdcrwfFJ2YkM0q5REQxOsOLhwHoV9gA==}
+  '@apps-in-toss/framework@2.0.5':
+    resolution: {integrity: sha512-qwaEjVd82ajsmgobNpcbFm0n7myeZLI7ebhT/uaVT1Eq/FK64UUz7Qh+WphVC9yfTQgpiRw2TjTzesCJWZcXzw==}
     hasBin: true
     peerDependencies:
       '@granite-js/native': '*'
@@ -153,39 +153,39 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/native-modules@2.0.4':
-    resolution: {integrity: sha512-fWbTY/00d2heTHg7QbTC0aLT5E44JyGj7x0aEqFNJe/D+LDdlnL4k6Erb2RSZUPStT9TXEP8QhB1hFt8e9hL/g==}
+  '@apps-in-toss/native-modules@2.0.5':
+    resolution: {integrity: sha512-u5ksLqQtBX+0+uqEEteVO7HfUxdFHrlGbF6/GTBO1tBVtInI5CBBg2aj4iZyAtd6j/pDTc/Lc3o9dcqmnmquqw==}
     peerDependencies:
       '@granite-js/native': '*'
       '@granite-js/react-native': '*'
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/plugin-compat@2.0.4':
-    resolution: {integrity: sha512-xgxEdZA+vxaNZLIN+XhacIMqCcctqg8aeTWjDqErgFMSEHnRh+CqaHbmuU7GIUwJRxq1ww3LBMb8k4lOLz0XDA==}
+  '@apps-in-toss/plugin-compat@2.0.5':
+    resolution: {integrity: sha512-ONBimPUSBJf4mZf75dDKu7qik1/AZjiDmnW6NuNpwngqyZRttnVvSshSOlXYvXzfU+ihmyH6aSx0YsAoKSoimg==}
 
-  '@apps-in-toss/plugins@2.0.4':
-    resolution: {integrity: sha512-XiFsZ4q/b/ptA+3vyb1WmHozj+dQSZlRrKifY9qyGx8xEOEIWA8pHpMNPRsCCnZ8G4JrTobG222cpRgXwOB9lw==}
+  '@apps-in-toss/plugins@2.0.5':
+    resolution: {integrity: sha512-af+5+guAI5Q/jDGRUvdpoLQUvzVzrKL8cYkhcXUEnZfO7QDMesCdOz5/xDzc0QnACYZ1wVIn+wGTeX0wap86tw==}
 
-  '@apps-in-toss/types@2.0.4':
-    resolution: {integrity: sha512-noz10bgTiBfEaEfH4SGPOwGEXspU9uk3vqEzrTukZgY+eVKSwWaNkU401YS6ISq0KhqZmuBKz7Mf/+I/x6yqHQ==}
+  '@apps-in-toss/types@2.0.5':
+    resolution: {integrity: sha512-hiHvdSya7pogdcs+Sw6j5SlYnoE7/H2z0wdG1742MK3TfgVNppVJ/nBoqlE6JMkS7W3xO3wvNQ5fm8Z1M4Q+Dw==}
 
-  '@apps-in-toss/user-scripts@2.0.4':
-    resolution: {integrity: sha512-kirlnbQQxfa/3IHgzgih3FEGhu8caHO6j6NX50HksQca2E/FWuU5NgVuFMHkfCPQy2+TEjWgLvwJrwp6s7/kwg==}
+  '@apps-in-toss/user-scripts@2.4.7':
+    resolution: {integrity: sha512-EQZr0QnFi3e2GzH+/+7XdWmbBuW1hANORFTWb8i2os/6UudGcPOTNJYkch7UOg+ZcEtsYYOQCCsXud0+VbphTA==}
 
-  '@apps-in-toss/web-analytics@2.0.4':
-    resolution: {integrity: sha512-BapbBgQZCKx9kMVF1ZBVsTMSsUUAkAoolP2O+IWEqn+gRzzMaUNsgx2YSKDb5qo1eQBprQ5iAMihPJJZeMqVPg==}
+  '@apps-in-toss/web-analytics@2.0.5':
+    resolution: {integrity: sha512-ux4l//poHulLTEmmYKIMfAjSgTM+Ev7adtaygN9Uf9On/MeU5AqdV9oTi0lCGpVU+IG4ed6dCZ8hAJIODna9KQ==}
     peerDependencies:
       '@apps-in-toss/web-bridge': '*'
 
-  '@apps-in-toss/web-bridge@2.0.4':
-    resolution: {integrity: sha512-uCAsAMUs+KOLPe+1fK20aggE4EqJd2MLc4t4DWfj+9W1TlbI6bNrnVvPO8pfhxvhQ9pqlbv+HJKY49dXezX6UA==}
+  '@apps-in-toss/web-bridge@2.0.5':
+    resolution: {integrity: sha512-uxMCDtVH4zunPFJcL7AcvBW8Dg2O8SrD3qDA88b5Ssggf1qfUoeZCWHbZkmtAmdRQNtV4BqebHW0h4I779dkLw==}
 
-  '@apps-in-toss/web-config@2.0.4':
-    resolution: {integrity: sha512-6MyH6mWHSQhY3OLJCYtNNgwLyjDqp27PJ7TDOQl3AMSylDzwNWi0OCM4Zg/uOOO8B+LjqQVv2/kTCMX6Hr9yaQ==}
+  '@apps-in-toss/web-config@2.0.5':
+    resolution: {integrity: sha512-wv9XVWhy+zQhWKEfyzfua2C7xzjWDwL25WccIZuxLwMZmb7Ghdg/B5QAUh2z8PZvsMzRhTx3ai8cCjtAkLzPXA==}
 
-  '@apps-in-toss/web-framework@2.0.4':
-    resolution: {integrity: sha512-PSFWjUtXdaDj3hCIUlObMhNq3Wag79ef7QT5PXd6gTI/qr11hDs5bhqi71xvVXY35VGwqoC+U6cSODQVV8z4HA==}
+  '@apps-in-toss/web-framework@2.0.5':
+    resolution: {integrity: sha512-eCdEN70NrKC0Lc+pTZHBVASv3H+XZDe7EpGpqPSkEWaL6keuhmu5ZrtiMEwN6SUlQjDo50bDolE6D7rHimRugg==}
     hasBin: true
 
   '@babel/code-frame@7.27.1':
@@ -7302,7 +7302,7 @@ snapshots:
       '@apps-in-toss/ait-format-proto': 1.0.0
       fflate: 0.8.2
 
-  '@apps-in-toss/analytics@2.0.4(5d4eaf8aba8e67f26797ecff98b4cbd7)':
+  '@apps-in-toss/analytics@2.0.5(5d4eaf8aba8e67f26797ecff98b4cbd7)':
     dependencies:
       '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
       '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
@@ -7311,13 +7311,13 @@ snapshots:
       react: 18.3.1
       react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
 
-  '@apps-in-toss/bridge-core@2.0.4': {}
+  '@apps-in-toss/bridge-core@2.0.5': {}
 
-  '@apps-in-toss/cli@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)':
+  '@apps-in-toss/cli@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)':
     dependencies:
       '@apps-in-toss/ait-format': 1.0.0
-      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/web-config': 2.0.4(@types/node@24.10.9)(typescript@5.9.3)
+      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/web-config': 2.0.5(@types/node@24.10.9)(typescript@5.9.3)
       '@clack/prompts': 0.10.1
       '@granite-js/utils': 1.0.4
       '@sentry/cli': 2.58.4
@@ -7352,14 +7352,14 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/framework@2.0.4(bb7f505b87a1e5d697dccbb968a2a61e)':
+  '@apps-in-toss/framework@2.0.5(bb7f505b87a1e5d697dccbb968a2a61e)':
     dependencies:
-      '@apps-in-toss/analytics': 2.0.4(5d4eaf8aba8e67f26797ecff98b4cbd7)
-      '@apps-in-toss/cli': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
-      '@apps-in-toss/native-modules': 2.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/types': 2.0.4
-      '@apps-in-toss/user-scripts': 2.0.4
+      '@apps-in-toss/analytics': 2.0.5(5d4eaf8aba8e67f26797ecff98b4cbd7)
+      '@apps-in-toss/cli': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
+      '@apps-in-toss/native-modules': 2.0.5(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/types': 2.0.5
+      '@apps-in-toss/user-scripts': 2.4.7
       '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
       '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
       '@toss/tds-react-native': 1.3.8(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
@@ -7389,9 +7389,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/native-modules@2.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@apps-in-toss/native-modules@2.0.5(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apps-in-toss/types': 2.0.4
+      '@apps-in-toss/types': 2.0.5
       '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
       '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
       brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
@@ -7399,7 +7399,7 @@ snapshots:
       react: 18.3.1
       react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
 
-  '@apps-in-toss/plugin-compat@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@apps-in-toss/plugin-compat@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
@@ -7457,10 +7457,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/plugins@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@apps-in-toss/plugins@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@apps-in-toss/ait-format': 1.0.0
-      '@apps-in-toss/plugin-compat': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/plugin-compat': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
       '@granite-js/plugin-micro-frontend': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
       '@granite-js/plugin-sentry': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
@@ -7492,19 +7492,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/types@2.0.4': {}
+  '@apps-in-toss/types@2.0.5': {}
 
-  '@apps-in-toss/user-scripts@2.0.4': {}
+  '@apps-in-toss/user-scripts@2.4.7': {}
 
-  '@apps-in-toss/web-analytics@2.0.4(@apps-in-toss/web-bridge@2.0.4)':
+  '@apps-in-toss/web-analytics@2.0.5(@apps-in-toss/web-bridge@2.0.5)':
     dependencies:
-      '@apps-in-toss/web-bridge': 2.0.4
+      '@apps-in-toss/web-bridge': 2.0.5
 
-  '@apps-in-toss/web-bridge@2.0.4':
+  '@apps-in-toss/web-bridge@2.0.5':
     dependencies:
-      '@apps-in-toss/types': 2.0.4
+      '@apps-in-toss/types': 2.0.5
 
-  '@apps-in-toss/web-config@2.0.4(@types/node@24.10.9)(typescript@5.9.3)':
+  '@apps-in-toss/web-config@2.0.5(@types/node@24.10.9)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/traverse': 7.29.0
@@ -7517,15 +7517,15 @@ snapshots:
       - supports-color
       - typescript
 
-  '@apps-in-toss/web-framework@2.0.4(ff0f2754757ec9b85c426f97bbe7019f)':
+  '@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f)':
     dependencies:
-      '@apps-in-toss/bridge-core': 2.0.4
-      '@apps-in-toss/cli': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
-      '@apps-in-toss/framework': 2.0.4(bb7f505b87a1e5d697dccbb968a2a61e)
-      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/web-analytics': 2.0.4(@apps-in-toss/web-bridge@2.0.4)
-      '@apps-in-toss/web-bridge': 2.0.4
-      '@apps-in-toss/web-config': 2.0.4(@types/node@24.10.9)(typescript@5.9.3)
+      '@apps-in-toss/bridge-core': 2.0.5
+      '@apps-in-toss/cli': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
+      '@apps-in-toss/framework': 2.0.5(bb7f505b87a1e5d697dccbb968a2a61e)
+      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/web-analytics': 2.0.5(@apps-in-toss/web-bridge@2.0.5)
+      '@apps-in-toss/web-bridge': 2.0.5
+      '@apps-in-toss/web-config': 2.0.5(@types/node@24.10.9)(typescript@5.9.3)
       '@babel/core': 7.23.9
       '@granite-js/cli': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
       '@granite-js/mpack': 1.0.4(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
@@ -12321,9 +12321,9 @@ snapshots:
 
   '@toss/tds-easings@0.0.1': {}
 
-  '@toss/tds-mobile-ait@2.3.0(@apps-in-toss/web-framework@2.0.4(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@toss/tds-mobile-ait@2.3.0(@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apps-in-toss/web-framework': 2.0.4(ff0f2754757ec9b85c426f97bbe7019f)
+      '@apps-in-toss/web-framework': 2.0.5(ff0f2754757ec9b85c426f97bbe7019f)
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
       '@toss/tds-colors': 0.1.0
       '@toss/tds-mobile': 2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@apps-in-toss/web-framework':
-        specifier: 2.0.5
-        version: 2.0.5(ff0f2754757ec9b85c426f97bbe7019f)
+        specifier: 2.0.4
+        version: 2.0.4(db56b279faff28d964e3c90e73441d89)
       '@emotion/react':
         specifier: ^11
         version: 11.14.0(@types/react@18.3.27)(react@18.3.1)
@@ -37,7 +37,7 @@ importers:
         version: 2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@toss/tds-mobile-ait':
         specifier: ^2.3.0
-        version: 2.3.0(@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 2.3.0(@apps-in-toss/web-framework@2.0.4(db56b279faff28d964e3c90e73441d89))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
         specifier: ^1.12.2
         version: 1.13.4
@@ -46,7 +46,7 @@ importers:
         version: 4.5.1
       firebase:
         specifier: ^11.0.0
-        version: 11.10.0(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))
+        version: 11.10.0(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))
       framer-motion:
         specifier: ^12.23.24
         version: 12.29.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -125,8 +125,8 @@ packages:
     resolution: {integrity: sha512-1no0CXOhPEeSCrGduT37KMmCqA6irhowXa0S7AaPHb4RQSHGioR3wvvD7HHBCaUriMYs0EvtqRJfOgYd0ycKlQ==}
     engines: {node: '>=24'}
 
-  '@apps-in-toss/analytics@2.0.5':
-    resolution: {integrity: sha512-9ZKIw8a6gVlO04TEO65FctmAjWgh9r1MfMru2X1iB57FcwknuYYLxT8rU1ANLebSBg19AZMWZKirsMKOVreqDQ==}
+  '@apps-in-toss/analytics@2.0.4':
+    resolution: {integrity: sha512-0bv5cSaqoUFHc2wI3pclB0jBQSzmAmXisEFHclJNQ/3nDWEwRB3rbofz8vi9qMzir2cR7v2fKZ2oujwcX5gPRQ==}
     peerDependencies:
       '@granite-js/native': '*'
       '@granite-js/react-native': '*'
@@ -135,14 +135,14 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/bridge-core@2.0.5':
-    resolution: {integrity: sha512-NAq214QjHsEfLp2qZSOm7NOwafI9Uv12y1y3X6sHOLInfe38NkKUDmSjwfM1GwE4h4f5rF4HsXnNu/FUvC2jcg==}
+  '@apps-in-toss/bridge-core@2.0.4':
+    resolution: {integrity: sha512-KaOiGjj+b4KwwSfN8vAFKaMcwsdDIHIB5cNJYSJ2gaL1/5wPpidSzd6mifOo7/a+f+MuoycfP6fmCuJCmf20AQ==}
 
-  '@apps-in-toss/cli@2.0.5':
-    resolution: {integrity: sha512-m0nXY2gxpd/IcT4mz3TIHzWVc10oU1CKIL2Ymmu50ivmlWeyaP43m0MifxqWq/tYyIc5w3e3v/wlJlb9PeXRwA==}
+  '@apps-in-toss/cli@2.0.4':
+    resolution: {integrity: sha512-GyDMmT6R7b8PHrD7E8SbSUS6bvKtUacIF7REDBENBsOFndScA4XY5O3H6k3j9KtdsD1gq1UhP4nFqDQgkXs80g==}
 
-  '@apps-in-toss/framework@2.0.5':
-    resolution: {integrity: sha512-qwaEjVd82ajsmgobNpcbFm0n7myeZLI7ebhT/uaVT1Eq/FK64UUz7Qh+WphVC9yfTQgpiRw2TjTzesCJWZcXzw==}
+  '@apps-in-toss/framework@2.0.4':
+    resolution: {integrity: sha512-7j2TSs3WIjE1N41BcbnRYsPYOOYGsutCPTz9Tg3Ihc263yLqCGUINdixdcrwfFJ2YkM0q5REQxOsOLhwHoV9gA==}
     hasBin: true
     peerDependencies:
       '@granite-js/native': '*'
@@ -153,39 +153,39 @@ packages:
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/native-modules@2.0.5':
-    resolution: {integrity: sha512-u5ksLqQtBX+0+uqEEteVO7HfUxdFHrlGbF6/GTBO1tBVtInI5CBBg2aj4iZyAtd6j/pDTc/Lc3o9dcqmnmquqw==}
+  '@apps-in-toss/native-modules@2.0.4':
+    resolution: {integrity: sha512-fWbTY/00d2heTHg7QbTC0aLT5E44JyGj7x0aEqFNJe/D+LDdlnL4k6Erb2RSZUPStT9TXEP8QhB1hFt8e9hL/g==}
     peerDependencies:
       '@granite-js/native': '*'
       '@granite-js/react-native': '*'
       react: '*'
       react-native: '*'
 
-  '@apps-in-toss/plugin-compat@2.0.5':
-    resolution: {integrity: sha512-ONBimPUSBJf4mZf75dDKu7qik1/AZjiDmnW6NuNpwngqyZRttnVvSshSOlXYvXzfU+ihmyH6aSx0YsAoKSoimg==}
+  '@apps-in-toss/plugin-compat@2.0.4':
+    resolution: {integrity: sha512-xgxEdZA+vxaNZLIN+XhacIMqCcctqg8aeTWjDqErgFMSEHnRh+CqaHbmuU7GIUwJRxq1ww3LBMb8k4lOLz0XDA==}
 
-  '@apps-in-toss/plugins@2.0.5':
-    resolution: {integrity: sha512-af+5+guAI5Q/jDGRUvdpoLQUvzVzrKL8cYkhcXUEnZfO7QDMesCdOz5/xDzc0QnACYZ1wVIn+wGTeX0wap86tw==}
+  '@apps-in-toss/plugins@2.0.4':
+    resolution: {integrity: sha512-XiFsZ4q/b/ptA+3vyb1WmHozj+dQSZlRrKifY9qyGx8xEOEIWA8pHpMNPRsCCnZ8G4JrTobG222cpRgXwOB9lw==}
 
-  '@apps-in-toss/types@2.0.5':
-    resolution: {integrity: sha512-hiHvdSya7pogdcs+Sw6j5SlYnoE7/H2z0wdG1742MK3TfgVNppVJ/nBoqlE6JMkS7W3xO3wvNQ5fm8Z1M4Q+Dw==}
+  '@apps-in-toss/types@2.0.4':
+    resolution: {integrity: sha512-noz10bgTiBfEaEfH4SGPOwGEXspU9uk3vqEzrTukZgY+eVKSwWaNkU401YS6ISq0KhqZmuBKz7Mf/+I/x6yqHQ==}
 
   '@apps-in-toss/user-scripts@2.4.7':
     resolution: {integrity: sha512-EQZr0QnFi3e2GzH+/+7XdWmbBuW1hANORFTWb8i2os/6UudGcPOTNJYkch7UOg+ZcEtsYYOQCCsXud0+VbphTA==}
 
-  '@apps-in-toss/web-analytics@2.0.5':
-    resolution: {integrity: sha512-ux4l//poHulLTEmmYKIMfAjSgTM+Ev7adtaygN9Uf9On/MeU5AqdV9oTi0lCGpVU+IG4ed6dCZ8hAJIODna9KQ==}
+  '@apps-in-toss/web-analytics@2.0.4':
+    resolution: {integrity: sha512-BapbBgQZCKx9kMVF1ZBVsTMSsUUAkAoolP2O+IWEqn+gRzzMaUNsgx2YSKDb5qo1eQBprQ5iAMihPJJZeMqVPg==}
     peerDependencies:
       '@apps-in-toss/web-bridge': '*'
 
-  '@apps-in-toss/web-bridge@2.0.5':
-    resolution: {integrity: sha512-uxMCDtVH4zunPFJcL7AcvBW8Dg2O8SrD3qDA88b5Ssggf1qfUoeZCWHbZkmtAmdRQNtV4BqebHW0h4I779dkLw==}
+  '@apps-in-toss/web-bridge@2.0.4':
+    resolution: {integrity: sha512-uCAsAMUs+KOLPe+1fK20aggE4EqJd2MLc4t4DWfj+9W1TlbI6bNrnVvPO8pfhxvhQ9pqlbv+HJKY49dXezX6UA==}
 
-  '@apps-in-toss/web-config@2.0.5':
-    resolution: {integrity: sha512-wv9XVWhy+zQhWKEfyzfua2C7xzjWDwL25WccIZuxLwMZmb7Ghdg/B5QAUh2z8PZvsMzRhTx3ai8cCjtAkLzPXA==}
+  '@apps-in-toss/web-config@2.0.4':
+    resolution: {integrity: sha512-6MyH6mWHSQhY3OLJCYtNNgwLyjDqp27PJ7TDOQl3AMSylDzwNWi0OCM4Zg/uOOO8B+LjqQVv2/kTCMX6Hr9yaQ==}
 
-  '@apps-in-toss/web-framework@2.0.5':
-    resolution: {integrity: sha512-eCdEN70NrKC0Lc+pTZHBVASv3H+XZDe7EpGpqPSkEWaL6keuhmu5ZrtiMEwN6SUlQjDo50bDolE6D7rHimRugg==}
+  '@apps-in-toss/web-framework@2.0.4':
+    resolution: {integrity: sha512-PSFWjUtXdaDj3hCIUlObMhNq3Wag79ef7QT5PXd6gTI/qr11hDs5bhqi71xvVXY35VGwqoC+U6cSODQVV8z4HA==}
     hasBin: true
 
   '@babel/code-frame@7.27.1':
@@ -7302,22 +7302,22 @@ snapshots:
       '@apps-in-toss/ait-format-proto': 1.0.0
       fflate: 0.8.2
 
-  '@apps-in-toss/analytics@2.0.5(5d4eaf8aba8e67f26797ecff98b4cbd7)':
+  '@apps-in-toss/analytics@2.0.4(186a38929984a908b87ec8fa5c8110f6)':
     dependencies:
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
       '@types/react': 18.3.27
-      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@apps-in-toss/bridge-core@2.0.5': {}
+  '@apps-in-toss/bridge-core@2.0.4': {}
 
-  '@apps-in-toss/cli@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)':
+  '@apps-in-toss/cli@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)':
     dependencies:
       '@apps-in-toss/ait-format': 1.0.0
-      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/web-config': 2.0.5(@types/node@24.10.9)(typescript@5.9.3)
+      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/web-config': 2.0.4(@types/node@24.10.9)(typescript@5.9.3)
       '@clack/prompts': 0.10.1
       '@granite-js/utils': 1.0.4
       '@sentry/cli': 2.58.4
@@ -7325,7 +7325,7 @@ snapshots:
       dedent: 1.7.1(babel-plugin-macros@3.1.0)
       execa: 9.3.0
       fast-glob: 3.3.3
-      jscodeshift: 17.3.0(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+      jscodeshift: 17.3.0(@babel/preset-env@7.28.5(@babel/core@7.23.9))
       source-map: 0.8.0-beta.0
       unzipper: 0.12.3
       uuidv7: 1.1.0
@@ -7352,22 +7352,22 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/framework@2.0.5(bb7f505b87a1e5d697dccbb968a2a61e)':
+  '@apps-in-toss/framework@2.0.4(d369f5696878c001bd4169feb4894b78)':
     dependencies:
-      '@apps-in-toss/analytics': 2.0.5(5d4eaf8aba8e67f26797ecff98b4cbd7)
-      '@apps-in-toss/cli': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
-      '@apps-in-toss/native-modules': 2.0.5(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/types': 2.0.5
+      '@apps-in-toss/analytics': 2.0.4(186a38929984a908b87ec8fa5c8110f6)
+      '@apps-in-toss/cli': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
+      '@apps-in-toss/native-modules': 2.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/types': 2.0.4
       '@apps-in-toss/user-scripts': 2.4.7
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
-      '@toss/tds-react-native': 1.3.8(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
+      '@toss/tds-react-native': 1.3.8(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.27
-      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       es-hangul: 2.3.8
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/preset-env'
@@ -7389,29 +7389,29 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/native-modules@2.0.5(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@apps-in-toss/native-modules@2.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apps-in-toss/types': 2.0.5
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
-      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@apps-in-toss/types': 2.0.4
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
+      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       es-toolkit: 1.44.0
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@apps-in-toss/plugin-compat@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@apps-in-toss/plugin-compat@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@babel/runtime': 7.28.6
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
-      '@react-native-async-storage/async-storage-1.18.2': '@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))'
-      '@react-native-community/blur-4.3.2': '@react-native-community/blur@4.3.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)'
-      '@react-native/codegen-0.72.6': '@react-native/codegen@0.72.6(@babel/preset-env@7.28.5(@babel/core@7.29.0))'
+      '@react-native-async-storage/async-storage-1.18.2': '@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))'
+      '@react-native-community/blur-4.3.2': '@react-native-community/blur@4.3.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)'
+      '@react-native/codegen-0.72.6': '@react-native/codegen@0.72.6(@babel/preset-env@7.28.5(@babel/core@7.23.9))'
       '@react-native/js-polyfills-0.72.1': '@react-native/js-polyfills@0.72.1'
       '@react-native/normalize-colors-0.72.0': '@react-native/normalize-colors@0.72.0'
-      '@react-navigation/elements-1.3.9': '@react-navigation/elements@1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)'
-      '@react-navigation/native-6.0.13': '@react-navigation/native@6.0.13(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)'
-      '@react-navigation/native-stack-6.9.0': '@react-navigation/native-stack@6.9.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)'
-      '@shopify/flash-list-1.6.2': '@shopify/flash-list@1.6.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)'
+      '@react-navigation/elements-1.3.9': '@react-navigation/elements@1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)'
+      '@react-navigation/native-6.0.13': '@react-navigation/native@6.0.13(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)'
+      '@react-navigation/native-stack-6.9.0': '@react-navigation/native-stack@6.9.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)'
+      '@shopify/flash-list-1.6.2': '@shopify/flash-list@1.6.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)'
       assert: 2.1.0
       browserify-zlib: 0.2.0
       buffer: 6.0.3
@@ -7419,19 +7419,19 @@ snapshots:
       es-toolkit: 1.44.0
       events: 3.3.0
       https-browserify: 1.0.0
-      lottie-react-native-6.4.0: lottie-react-native@6.4.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      lottie-react-native-6.4.0: lottie-react-native@6.4.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       path-browserify: 1.0.1
       react-18.2.0: react@18.2.0
       react-dom-18.2.0: react-dom@18.2.0(react@18.3.1)
-      react-native-0.72.6: react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-fast-image-8.6.3: react-native-fast-image@8.6.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-gesture-handler-2.8.0: react-native-gesture-handler@2.8.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-pager-view-6.1.2: react-native-pager-view@6.1.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-safe-area-context-4.7.4: react-native-safe-area-context@4.7.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-screens-3.27.0: react-native-screens@3.27.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-svg-13.14.0: react-native-svg@13.14.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native-0.72.6: react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-fast-image-8.6.3: react-native-fast-image@8.6.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-gesture-handler-2.8.0: react-native-gesture-handler@2.8.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-pager-view-6.1.2: react-native-pager-view@6.1.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-safe-area-context-4.7.4: react-native-safe-area-context@4.7.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-screens-3.27.0: react-native-screens@3.27.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-svg-13.14.0: react-native-svg@13.14.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react-native-video-6.0.0-alpha.6: react-native-video@6.0.0-alpha.6
-      react-native-webview-13.6.3: react-native-webview@13.6.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native-webview-13.6.3: react-native-webview@13.6.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react18-use: 0.4.1(react@18.3.1)
       stream-browserify: 3.0.0
       stream-http: 3.2.0
@@ -7457,10 +7457,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/plugins@2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
+  '@apps-in-toss/plugins@2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)':
     dependencies:
       '@apps-in-toss/ait-format': 1.0.0
-      '@apps-in-toss/plugin-compat': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/plugin-compat': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
       '@granite-js/plugin-micro-frontend': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
       '@granite-js/plugin-sentry': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
@@ -7492,19 +7492,19 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@apps-in-toss/types@2.0.5': {}
+  '@apps-in-toss/types@2.0.4': {}
 
   '@apps-in-toss/user-scripts@2.4.7': {}
 
-  '@apps-in-toss/web-analytics@2.0.5(@apps-in-toss/web-bridge@2.0.5)':
+  '@apps-in-toss/web-analytics@2.0.4(@apps-in-toss/web-bridge@2.0.4)':
     dependencies:
-      '@apps-in-toss/web-bridge': 2.0.5
+      '@apps-in-toss/web-bridge': 2.0.4
 
-  '@apps-in-toss/web-bridge@2.0.5':
+  '@apps-in-toss/web-bridge@2.0.4':
     dependencies:
-      '@apps-in-toss/types': 2.0.5
+      '@apps-in-toss/types': 2.0.4
 
-  '@apps-in-toss/web-config@2.0.5(@types/node@24.10.9)(typescript@5.9.3)':
+  '@apps-in-toss/web-config@2.0.4(@types/node@24.10.9)(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.23.9
       '@babel/traverse': 7.29.0
@@ -7517,23 +7517,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f)':
+  '@apps-in-toss/web-framework@2.0.4(db56b279faff28d964e3c90e73441d89)':
     dependencies:
-      '@apps-in-toss/bridge-core': 2.0.5
-      '@apps-in-toss/cli': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
-      '@apps-in-toss/framework': 2.0.5(bb7f505b87a1e5d697dccbb968a2a61e)
-      '@apps-in-toss/plugins': 2.0.5(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
-      '@apps-in-toss/web-analytics': 2.0.5(@apps-in-toss/web-bridge@2.0.5)
-      '@apps-in-toss/web-bridge': 2.0.5
-      '@apps-in-toss/web-config': 2.0.5(@types/node@24.10.9)(typescript@5.9.3)
+      '@apps-in-toss/bridge-core': 2.0.4
+      '@apps-in-toss/cli': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typanion@3.14.0)(typescript@5.9.3)
+      '@apps-in-toss/framework': 2.0.4(d369f5696878c001bd4169feb4894b78)
+      '@apps-in-toss/plugins': 2.0.4(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)
+      '@apps-in-toss/web-analytics': 2.0.4(@apps-in-toss/web-bridge@2.0.4)
+      '@apps-in-toss/web-bridge': 2.0.4
+      '@apps-in-toss/web-config': 2.0.4(@types/node@24.10.9)(typescript@5.9.3)
       '@babel/core': 7.23.9
       '@granite-js/cli': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
       '@granite-js/mpack': 1.0.4(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
-      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
+      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
       '@granite-js/utils': 1.0.4
-      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/preset-env'
       - '@babel/runtime'
@@ -7907,6 +7907,14 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -7915,22 +7923,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.28.5(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-class-field-initializer-scope@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.28.5)':
@@ -7938,10 +7943,14 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.23.9)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.28.5)':
     dependencies:
@@ -7952,26 +7961,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
@@ -8162,13 +8162,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+
   '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-
-  '@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
 
   '@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.28.5)':
     dependencies:
@@ -8265,14 +8265,19 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.28.5)':
@@ -8420,16 +8425,16 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-arrow-functions@7.27.1(@babel/core@7.23.9)':
@@ -8447,20 +8452,20 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.23.9)
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.28.5)
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-async-generator-functions@7.29.0(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -8522,6 +8527,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-class-properties@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8538,18 +8551,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.5)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.23.9
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-class-static-block@7.28.6(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -8632,16 +8645,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dotall-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.28.5)':
@@ -8649,9 +8667,10 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-keys@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.28.5)':
@@ -8660,10 +8679,9 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.28.5)':
@@ -8671,10 +8689,13 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-dynamic-import@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.23.9)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.28.5)':
     dependencies:
@@ -8684,32 +8705,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-explicit-resource-management@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-exponentiation-operator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-export-namespace-from@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-flow-strip-types@7.27.1(@babel/core@7.23.9)':
@@ -8781,14 +8794,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-json-strings@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-literals@7.27.1(@babel/core@7.23.9)':
@@ -8806,14 +8819,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-logical-assignment-operators@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-member-expression-literals@7.27.1(@babel/core@7.23.9)':
@@ -8831,18 +8844,18 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.28.5
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
+      '@babel/core': 7.23.9
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-amd@7.27.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.28.5
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -8871,6 +8884,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -8881,13 +8904,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-systemjs@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.23.9
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8895,14 +8916,6 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-modules-umd@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -8925,14 +8938,19 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-new-target@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-nullish-coalescing-operator@7.28.6(@babel/core@7.28.5)':
@@ -8945,15 +8963,26 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-numeric-separator@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.23.9)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.23.9)
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.28.5)':
     dependencies:
@@ -8962,17 +8991,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.28.5)
       '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.28.5)
-      '@babel/traverse': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-object-rest-spread@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
       '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -9001,15 +9019,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-optional-catch-binding@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-transform-optional-chaining@7.28.6(@babel/core@7.28.5)':
     dependencies:
@@ -9042,6 +9068,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-private-methods@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
@@ -9058,20 +9092,20 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-annotate-as-pure': 7.27.3
+      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.28.6
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/plugin-transform-private-property-in-object@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-create-class-features-plugin': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
@@ -9182,14 +9216,20 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regenerator@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.28.5)':
@@ -9198,20 +9238,14 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-regexp-modifiers@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-reserved-words@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-runtime@7.29.0(@babel/core@7.23.9)':
@@ -9319,14 +9353,14 @@ snapshots:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-typeof-symbol@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-typescript@7.28.6(@babel/core@7.23.9)':
@@ -9362,26 +9396,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-escapes@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-unicode-property-regex@7.28.6(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/plugin-transform-unicode-regex@7.27.1(@babel/core@7.23.9)':
@@ -9402,17 +9436,93 @@ snapshots:
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
 
+  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.23.9)':
+    dependencies:
+      '@babel/core': 7.23.9
+      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.23.9)
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.28.5)':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.28.5)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-unicode-sets-regex@7.28.6(@babel/core@7.29.0)':
+  '@babel/preset-env@7.28.5(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-regexp-features-plugin': 7.28.5(@babel/core@7.29.0)
+      '@babel/compat-data': 7.29.0
+      '@babel/core': 7.23.9
+      '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
+      '@babel/helper-validator-option': 7.27.1
+      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.23.9)
+      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.23.9)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.23.9)
+      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.23.9)
+      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.23.9)
+      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.23.9)
+      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.23.9)
+      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.23.9)
+      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.23.9)
+      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.23.9)
+      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.23.9)
+      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.23.9)
+      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.23.9)
+      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.23.9)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.23.9)
+      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.23.9)
+      core-js-compat: 3.48.0
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/preset-env@7.28.5(@babel/core@7.28.5)':
     dependencies:
@@ -9490,82 +9600,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/preset-env@7.28.5(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/compat-data': 7.29.0
-      '@babel/core': 7.29.0
-      '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-plugin-utils': 7.28.6
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-class-field-initializer-scope': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-attributes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-unicode-sets-regex': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-generator-functions': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-async-to-generator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoped-functions': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-block-scoping': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-classes': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-computed-properties': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-destructuring': 7.28.5(@babel/core@7.29.0)
-      '@babel/plugin-transform-dotall-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-keys': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-duplicate-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-dynamic-import': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-explicit-resource-management': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-exponentiation-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-for-of': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-function-name': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-json-strings': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-member-expression-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-amd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-systemjs': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-modules-umd': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-new-target': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-numeric-separator': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-object-super': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-catch-binding': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-optional-chaining': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-methods': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-private-property-in-object': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-regenerator': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-spread': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-sticky-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-typeof-symbol': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-escapes': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-property-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-regex': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs2: 0.4.15(@babel/core@7.29.0)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.0)
-      babel-plugin-polyfill-regenerator: 0.6.6(@babel/core@7.29.0)
-      core-js-compat: 3.48.0
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/preset-flow@7.27.1(@babel/core@7.29.0)':
     dependencies:
       '@babel/core': 7.29.0
@@ -9573,16 +9607,16 @@ snapshots:
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-transform-flow-strip-types': 7.27.1(@babel/core@7.29.0)
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.23.9)':
     dependencies:
-      '@babel/core': 7.28.5
+      '@babel/core': 7.23.9
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
 
-  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.0)':
+  '@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.28.5)':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.28.5
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/types': 7.29.0
       esutils: 2.0.3
@@ -10222,10 +10256,10 @@ snapshots:
       idb: 7.1.1
       tslib: 2.8.1
 
-  '@firebase/auth-compat@0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))':
+  '@firebase/auth-compat@0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))':
     dependencies:
       '@firebase/app-compat': 0.4.2
-      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))
+      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))
       '@firebase/auth-types': 0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.12.1)
       '@firebase/component': 0.6.18
       '@firebase/util': 1.12.1
@@ -10242,7 +10276,7 @@ snapshots:
       '@firebase/app-types': 0.9.3
       '@firebase/util': 1.12.1
 
-  '@firebase/auth@1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))':
+  '@firebase/auth@1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))':
     dependencies:
       '@firebase/app': 0.13.2
       '@firebase/component': 0.6.18
@@ -10250,7 +10284,7 @@ snapshots:
       '@firebase/util': 1.12.1
       tslib: 2.8.1
     optionalDependencies:
-      '@react-native-async-storage/async-storage': 1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))
+      '@react-native-async-storage/async-storage': 1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))
 
   '@firebase/component@0.6.18':
     dependencies:
@@ -10476,12 +10510,12 @@ snapshots:
       '@shikijs/types': 3.22.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@granite-js/blur-view@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/blur-view@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.27
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@granite-js/cli@1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
@@ -10514,17 +10548,17 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@granite-js/image@1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/image@1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@granite-js/jest@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/jest@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       jest: 29.7.0(@types/node@24.10.9)(babel-plugin-macros@3.1.0)
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -10532,10 +10566,10 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@granite-js/lottie@1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/lottie@1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@granite-js/mpack@1.0.4(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
@@ -10646,26 +10680,26 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
-      '@granite-js/image': 1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/lottie': 1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/video': 1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-native-async-storage/async-storage': 2.2.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))
-      '@react-native-community/blur': 4.4.1(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-navigation/native-stack': 7.12.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@shopify/flash-list': 2.2.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/image': 1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/lottie': 1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/video': 1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-native-async-storage/async-storage': 2.2.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))
+      '@react-native-community/blur': 4.4.1(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native-stack': 7.12.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@shopify/flash-list': 2.2.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-gesture-handler: 2.30.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-pager-view: 7.0.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-svg: 15.15.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-webview: 13.16.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-gesture-handler: 2.30.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-pager-view: 7.0.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-svg: 15.15.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-webview: 13.16.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
@@ -10712,23 +10746,23 @@ snapshots:
       - supports-color
       - typescript
 
-  '@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)':
+  '@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)':
     dependencies:
-      '@granite-js/blur-view': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/blur-view': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@granite-js/cli': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
-      '@granite-js/jest': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/jest': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@types/node@24.10.9)(babel-plugin-macros@3.1.0)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@granite-js/mpack': 1.0.4(@types/node@24.10.9)(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.3)
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@granite-js/plugin-core': 1.0.4(@swc/helpers@0.5.17)(@types/node@24.10.9)(typescript@5.9.3)
-      '@granite-js/style-utils': 1.0.4(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/video': 1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/style-utils': 1.0.4(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/video': 1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@standard-schema/spec': 1.1.0
       '@types/react': 18.3.27
-      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      brick-module: 0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       es-toolkit: 1.44.0
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-url-polyfill: 3.0.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-url-polyfill: 3.0.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))
     transitivePeerDependencies:
       - '@microsoft/api-extractor'
       - '@swc/helpers'
@@ -10746,20 +10780,20 @@ snapshots:
       - utf-8-validate
       - yaml
 
-  '@granite-js/style-utils@1.0.4(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/style-utils@1.0.4(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@types/react': 18.3.27
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@granite-js/utils@1.0.4':
     dependencies:
       yauzl: 3.2.0
 
-  '@granite-js/video@1.0.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@granite-js/video@1.0.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@grpc/grpc-js@1.9.15':
     dependencies:
@@ -11359,25 +11393,25 @@ snapshots:
 
   '@protobufjs/utf8@1.1.0': {}
 
-  '@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))':
+  '@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@react-native-async-storage/async-storage@2.2.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))':
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))':
     dependencies:
       merge-options: 3.0.4
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@react-native-community/blur@4.3.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-native-community/blur@4.3.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@react-native-community/blur@4.4.1(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-native-community/blur@4.4.1(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@react-native-community/cli-clean@11.3.7':
     dependencies:
@@ -11499,26 +11533,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@react-native-community/cli-plugin-metro@11.3.7(@babel/core@7.29.0)':
-    dependencies:
-      '@react-native-community/cli-server-api': 11.3.7
-      '@react-native-community/cli-tools': 11.3.7
-      chalk: 4.1.2
-      execa: 5.1.1
-      metro: 0.76.8
-      metro-config: 0.76.8
-      metro-core: 0.76.8
-      metro-react-native-babel-transformer: 0.76.8(@babel/core@7.29.0)
-      metro-resolver: 0.76.8
-      metro-runtime: 0.76.8
-      readline: 1.3.0
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
   '@react-native-community/cli-server-api@11.3.7':
     dependencies:
       '@react-native-community/cli-debugger-ui': 11.3.7
@@ -11562,32 +11576,6 @@ snapshots:
       '@react-native-community/cli-doctor': 11.3.7
       '@react-native-community/cli-hermes': 11.3.7
       '@react-native-community/cli-plugin-metro': 11.3.7(@babel/core@7.23.9)
-      '@react-native-community/cli-server-api': 11.3.7
-      '@react-native-community/cli-tools': 11.3.7
-      '@react-native-community/cli-types': 11.3.7
-      chalk: 4.1.2
-      commander: 9.5.0
-      execa: 5.1.1
-      find-up: 4.1.0
-      fs-extra: 8.1.0
-      graceful-fs: 4.2.11
-      prompts: 2.4.2
-      semver: 7.7.4
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  '@react-native-community/cli@11.3.7(@babel/core@7.29.0)':
-    dependencies:
-      '@react-native-community/cli-clean': 11.3.7
-      '@react-native-community/cli-config': 11.3.7
-      '@react-native-community/cli-debugger-ui': 11.3.7
-      '@react-native-community/cli-doctor': 11.3.7
-      '@react-native-community/cli-hermes': 11.3.7
-      '@react-native-community/cli-plugin-metro': 11.3.7(@babel/core@7.29.0)
       '@react-native-community/cli-server-api': 11.3.7
       '@react-native-community/cli-tools': 11.3.7
       '@react-native-community/cli-types': 11.3.7
@@ -11654,24 +11642,24 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.72.6(@babel/preset-env@7.28.5(@babel/core@7.29.0))':
+  '@react-native/codegen@0.72.6(@babel/preset-env@7.28.5(@babel/core@7.23.9))':
     dependencies:
       '@babel/parser': 7.29.2
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.23.9)
       flow-parser: 0.206.0
-      jscodeshift: 0.14.0(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+      jscodeshift: 0.14.0(@babel/preset-env@7.28.5(@babel/core@7.23.9))
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
 
-  '@react-native/codegen@0.72.8(@babel/preset-env@7.28.5(@babel/core@7.29.0))':
+  '@react-native/codegen@0.72.8(@babel/preset-env@7.28.5(@babel/core@7.23.9))':
     dependencies:
       '@babel/parser': 7.29.2
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.23.9)
       flow-parser: 0.206.0
       glob: 7.2.3
       invariant: 2.2.4
-      jscodeshift: 0.14.0(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+      jscodeshift: 0.14.0(@babel/preset-env@7.28.5(@babel/core@7.23.9))
       mkdirp: 0.5.6
       nullthrows: 1.1.1
     transitivePeerDependencies:
@@ -11724,11 +11712,11 @@ snapshots:
 
   '@react-native/normalize-colors@0.72.0': {}
 
-  '@react-native/virtualized-lists@0.72.8(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))':
+  '@react-native/virtualized-lists@0.72.8(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))':
     dependencies:
       invariant: 2.2.4
       nullthrows: 1.1.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@react-navigation/core@6.4.17(react@18.3.1)':
     dependencies:
@@ -11752,64 +11740,64 @@ snapshots:
       use-latest-callback: 0.2.6(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@react-navigation/elements@1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/elements@1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
 
-  '@react-navigation/elements@2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/elements@2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       color: 4.2.3
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       use-latest-callback: 0.2.6(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
-  '@react-navigation/native-stack@6.9.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/native-stack@6.9.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-navigation/elements': 1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/elements': 1.3.9(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       warn-once: 0.1.1
 
-  '@react-navigation/native-stack@7.12.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/native-stack@7.12.0(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/elements': 2.9.5(@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@react-navigation/native': 7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       color: 4.2.3
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      react-native-safe-area-context: 5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      react-native-screens: 4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       sf-symbols-typescript: 2.2.0
       warn-once: 0.1.1
     transitivePeerDependencies:
       - '@react-native-masked-view/masked-view'
 
-  '@react-navigation/native@6.0.13(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/native@6.0.13(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-navigation/core': 6.4.17(react@18.3.1)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  '@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-navigation/native@7.1.28(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-navigation/core': 7.16.1(react@18.3.1)
       escape-string-regexp: 4.0.0
       fast-deep-equal: 3.1.3
       nanoid: 3.3.11
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       use-latest-callback: 0.2.6(react@18.3.1)
 
   '@react-navigation/routers@6.1.9':
@@ -11834,14 +11822,14 @@ snapshots:
       '@react-spring/types': 9.5.5
       react: 18.3.1
 
-  '@react-spring/native@9.5.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@react-spring/native@9.5.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-spring/animated': 9.5.5(react@18.3.1)
       '@react-spring/core': 9.5.5(react@18.3.1)
       '@react-spring/shared': 9.5.5(react@18.3.1)
       '@react-spring/types': 9.5.5
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@react-spring/rafz@9.5.5': {}
 
@@ -12139,19 +12127,19 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@shopify/flash-list@1.6.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@shopify/flash-list@1.6.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      recyclerlistview: 4.2.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      recyclerlistview: 4.2.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       tslib: 2.4.0
 
-  '@shopify/flash-list@2.2.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@shopify/flash-list@2.2.2(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   '@shopify/semaphore@3.1.0': {}
 
@@ -12321,9 +12309,9 @@ snapshots:
 
   '@toss/tds-easings@0.0.1': {}
 
-  '@toss/tds-mobile-ait@2.3.0(@apps-in-toss/web-framework@2.0.5(ff0f2754757ec9b85c426f97bbe7019f))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@toss/tds-mobile-ait@2.3.0(@apps-in-toss/web-framework@2.0.4(db56b279faff28d964e3c90e73441d89))(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(@toss/tds-mobile@2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@apps-in-toss/web-framework': 2.0.5(ff0f2754757ec9b85c426f97bbe7019f)
+      '@apps-in-toss/web-framework': 2.0.4(db56b279faff28d964e3c90e73441d89)
       '@emotion/react': 11.14.0(@types/react@18.3.27)(react@18.3.1)
       '@toss/tds-colors': 0.1.0
       '@toss/tds-mobile': 2.3.0(@emotion/react@11.14.0(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -12336,11 +12324,11 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@toss/tds-react-native@1.3.8(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)':
+  '@toss/tds-react-native@1.3.8(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@granite-js/react-native@1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3))(@types/react@18.3.27)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
-      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
-      '@react-spring/native': 9.5.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1)
+      '@granite-js/native': 1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
+      '@granite-js/react-native': 1.0.4(@granite-js/native@1.0.4(@babel/runtime@7.28.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(@swc/helpers@0.5.17)(@types/node@24.10.9)(@types/react@18.3.27)(babel-plugin-macros@3.1.0)(brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1))(jiti@2.6.1)(postcss@8.5.6)(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(yaml@2.8.3)
+      '@react-spring/native': 9.5.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1)
       '@react-stately/radio': 3.11.5(react@18.3.1)
       '@toss/tds-color-utils': 0.0.2
       '@toss/tds-colors': 0.1.0
@@ -12353,7 +12341,7 @@ snapshots:
       hex-to-rgba: 2.0.1
       react: 18.3.1
       react-hook-form: 7.72.0(react@18.3.1)
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       react-uid: 2.4.0(@types/react@18.3.27)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
@@ -12968,11 +12956,11 @@ snapshots:
       ts-morph: 27.0.2
       typescript: 5.9.3
 
-  brick-module@0.5.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  brick-module@0.5.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       brick-codegen: 0.5.0
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   browserify-zlib@0.2.0:
     dependencies:
@@ -13822,7 +13810,7 @@ snapshots:
       locate-path: 8.0.0
       unicorn-magic: 0.3.0
 
-  firebase@11.10.0(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))):
+  firebase@11.10.0(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))):
     dependencies:
       '@firebase/ai': 1.4.1(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)
       '@firebase/analytics': 0.10.17(@firebase/app@0.13.2)
@@ -13832,8 +13820,8 @@ snapshots:
       '@firebase/app-check-compat': 0.3.26(@firebase/app-compat@0.4.2)(@firebase/app@0.13.2)
       '@firebase/app-compat': 0.4.2
       '@firebase/app-types': 0.9.3
-      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))
-      '@firebase/auth-compat': 0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)))
+      '@firebase/auth': 1.10.8(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))
+      '@firebase/auth-compat': 0.5.28(@firebase/app-compat@0.4.2)(@firebase/app-types@0.9.3)(@firebase/app@0.13.2)(@react-native-async-storage/async-storage@1.18.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)))
       '@firebase/data-connect': 0.3.10(@firebase/app@0.13.2)
       '@firebase/database': 1.0.20
       '@firebase/database-compat': 2.0.11
@@ -14658,7 +14646,7 @@ snapshots:
 
   jsc-safe-url@0.2.4: {}
 
-  jscodeshift@0.14.0(@babel/preset-env@7.28.5(@babel/core@7.29.0)):
+  jscodeshift@0.14.0(@babel/preset-env@7.28.5(@babel/core@7.23.9)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -14666,7 +14654,7 @@ snapshots:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.18.6(@babel/core@7.29.0)
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.29.0)
       '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.0)
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.23.9)
       '@babel/preset-flow': 7.27.1(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@babel/register': 7.28.6(@babel/core@7.29.0)
@@ -14683,7 +14671,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.29.0)):
+  jscodeshift@17.3.0(@babel/preset-env@7.28.5(@babel/core@7.23.9)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2
@@ -14704,7 +14692,7 @@ snapshots:
       tmp: 0.2.5
       write-file-atomic: 5.0.1
     optionalDependencies:
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-env': 7.28.5(@babel/core@7.23.9)
     transitivePeerDependencies:
       - supports-color
 
@@ -14950,10 +14938,10 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lottie-react-native@6.4.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  lottie-react-native@6.4.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
   lower-case@2.0.2:
     dependencies:
@@ -15337,16 +15325,6 @@ snapshots:
       babel-preset-fbjs: 3.4.0(@babel/core@7.28.5)
       hermes-parser: 0.12.0
       metro-react-native-babel-preset: 0.76.8(@babel/core@7.28.5)
-      nullthrows: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
-
-  metro-react-native-babel-transformer@0.76.8(@babel/core@7.29.0):
-    dependencies:
-      '@babel/core': 7.29.0
-      babel-preset-fbjs: 3.4.0(@babel/core@7.29.0)
-      hermes-parser: 0.12.0
-      metro-react-native-babel-preset: 0.76.8(@babel/core@7.29.0)
       nullthrows: 1.1.1
     transitivePeerDependencies:
       - supports-color
@@ -16074,20 +16052,20 @@ snapshots:
 
   react-is@19.2.4: {}
 
-  react-native-fast-image@8.6.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-fast-image@8.6.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-gesture-handler@2.30.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-gesture-handler@2.30.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
       invariant: 2.2.4
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-gesture-handler@2.8.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-gesture-handler@2.8.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@egjs/hammerjs': 2.0.17
       hoist-non-react-statics: 3.3.2
@@ -16095,60 +16073,60 @@ snapshots:
       lodash: 4.17.23
       prop-types: 15.8.1
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-pager-view@6.1.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-pager-view@6.1.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-pager-view@7.0.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-pager-view@7.0.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-safe-area-context@4.7.4(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-safe-area-context@4.7.4(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-safe-area-context@5.6.2(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-screens@3.27.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
-    dependencies:
-      react: 18.3.1
-      react-freeze: 1.0.4(react@18.3.1)
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
-      warn-once: 0.1.1
-
-  react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-screens@3.27.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-freeze: 1.0.4(react@18.3.1)
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       warn-once: 0.1.1
 
-  react-native-svg@13.14.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-screens@4.23.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+      react-freeze: 1.0.4(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
+      warn-once: 0.1.1
+
+  react-native-svg@13.14.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-svg@15.15.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-svg@15.15.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       css-select: 5.2.2
       css-tree: 1.1.3
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       warn-once: 0.1.1
 
-  react-native-url-polyfill@3.0.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)):
+  react-native-url-polyfill@3.0.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)):
     dependencies:
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       whatwg-url-without-unicode: 8.0.0-3
 
   react-native-video@6.0.0-alpha.6:
@@ -16157,79 +16135,32 @@ snapshots:
       keymirror: 0.1.1
       prop-types: 15.8.1
 
-  react-native-webview@13.16.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-webview@13.16.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       escape-string-regexp: 4.0.0
       invariant: 2.2.4
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native-webview@13.6.3(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  react-native-webview@13.6.3(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       escape-string-regexp: 2.0.0
       invariant: 2.2.4
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
 
-  react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1):
+  react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1):
     dependencies:
       '@jest/create-cache-key-function': 29.7.0
       '@react-native-community/cli': 11.3.7(@babel/core@7.23.9)
       '@react-native-community/cli-platform-android': 11.3.7
       '@react-native-community/cli-platform-ios': 11.3.7
       '@react-native/assets-registry': 0.72.0
-      '@react-native/codegen': 0.72.8(@babel/preset-env@7.28.5(@babel/core@7.29.0))
+      '@react-native/codegen': 0.72.8(@babel/preset-env@7.28.5(@babel/core@7.23.9))
       '@react-native/gradle-plugin': 0.72.11
       '@react-native/js-polyfills': 0.72.1
       '@react-native/normalize-colors': 0.72.0
-      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))
-      abort-controller: 3.0.0
-      anser: 1.4.10
-      base64-js: 1.5.1
-      deprecated-react-native-prop-types: 4.1.0
-      event-target-shim: 5.0.1
-      flow-enums-runtime: 0.0.5
-      invariant: 2.2.4
-      jest-environment-node: 29.7.0
-      jsc-android: 250231.0.0
-      memoize-one: 5.2.1
-      metro-runtime: 0.76.8
-      metro-source-map: 0.76.8
-      mkdirp: 0.5.6
-      nullthrows: 1.1.1
-      pretty-format: 26.6.2
-      promise: 8.3.0
-      react: 18.3.1
-      react-devtools-core: 4.28.5
-      react-refresh: 0.4.3
-      react-shallow-renderer: 16.15.0(react@18.3.1)
-      regenerator-runtime: 0.13.11
-      scheduler: 0.24.0-canary-efb381bbf-20230505
-      stacktrace-parser: 0.1.11
-      use-sync-external-store: 1.6.0(react@18.3.1)
-      whatwg-fetch: 3.6.20
-      ws: 6.2.3
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@babel/preset-env'
-      - bufferutil
-      - encoding
-      - supports-color
-      - utf-8-validate
-
-  react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1):
-    dependencies:
-      '@jest/create-cache-key-function': 29.7.0
-      '@react-native-community/cli': 11.3.7(@babel/core@7.29.0)
-      '@react-native-community/cli-platform-android': 11.3.7
-      '@react-native-community/cli-platform-ios': 11.3.7
-      '@react-native/assets-registry': 0.72.0
-      '@react-native/codegen': 0.72.8(@babel/preset-env@7.28.5(@babel/core@7.29.0))
-      '@react-native/gradle-plugin': 0.72.11
-      '@react-native/js-polyfills': 0.72.1
-      '@react-native/normalize-colors': 0.72.0
-      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))
+      '@react-native/virtualized-lists': 0.72.8(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))
       abort-controller: 3.0.0
       anser: 1.4.10
       base64-js: 1.5.1
@@ -16361,12 +16292,12 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recyclerlistview@4.2.0(react-native@0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1))(react@18.3.1):
+  recyclerlistview@4.2.0(react-native@0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1))(react@18.3.1):
     dependencies:
       lodash.debounce: 4.0.8
       prop-types: 15.8.1
       react: 18.3.1
-      react-native: 0.72.6(@babel/core@7.29.0)(@babel/preset-env@7.28.5(@babel/core@7.29.0))(react@18.3.1)
+      react-native: 0.72.6(@babel/core@7.23.9)(@babel/preset-env@7.28.5(@babel/core@7.23.9))(react@18.3.1)
       ts-object-utils: 0.0.5
 
   regenerate-unicode-properties@10.2.2:

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -34,8 +34,11 @@ export const Intro = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const returnTo = (location.state as LocationStateWithReturnTo)?.returnTo;
-	const [isIneligibleBottomSheetOpen, setIsIneligibleBottomSheetOpen] =
-		useState(false);
+	const [ineligibleSurveySheet, setIneligibleSurveySheet] = useState<{
+		open: boolean;
+		title?: string;
+		description?: string;
+	}>({ open: false });
 
 	const { data: openStats, isPending: isOpenStatsPending } =
 		useSurveyOpenStats();
@@ -160,27 +163,30 @@ export const Intro = () => {
 			void sendUserInfoEvent("Toss");
 
 			let targetSummary: OngoingSurveySummary | undefined;
-			let listedSurveyCount = 0;
 			try {
 				const result = await getAllOngoingSurveys({
 					lastSurveyId: 0,
 					size: 100,
 				});
 				const surveys = result.surveys ?? [];
-				listedSurveyCount = surveys.length;
 				targetSummary = pickHighestPriceAmongEligible(surveys);
 			} catch (error) {
 				console.error("진행 설문 목록 조회 실패:", error);
-				navigate("/home", { replace: true });
+				setIneligibleSurveySheet({
+					open: true,
+					title: "설문 목록을 불러오지 못했어요",
+					description:
+						"잠시 후 다시 시도하거나, 하단 다음 버튼으로 홈에서 확인해 주세요.",
+				});
 				return;
 			}
 
 			if (!targetSummary) {
-				if (listedSurveyCount > 0) {
-					setIsIneligibleBottomSheetOpen(true);
-				} else {
-					navigate("/home", { replace: true });
-				}
+				setIneligibleSurveySheet({
+					open: true,
+					title: "지금 참여할 수 있는 설문이 없어요",
+					description: `로그인 후 조건에 맞는 설문이 없어요. \n새 설문이 열리면 홈에서 참여할 수 있어요.`,
+				});
 				return;
 			}
 
@@ -361,8 +367,10 @@ export const Intro = () => {
 			</FixedBottomCTA>
 
 			<IneligibleSurveyBottomSheet
-				open={isIneligibleBottomSheetOpen}
-				onClose={() => setIsIneligibleBottomSheetOpen(false)}
+				open={ineligibleSurveySheet.open}
+				title={ineligibleSurveySheet.title}
+				description={ineligibleSurveySheet.description}
+				onClose={() => setIneligibleSurveySheet({ open: false })}
 			/>
 		</section>
 	);

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -1,5 +1,4 @@
 import { appLogin } from "@apps-in-toss/web-framework";
-import { IneligibleSurveyBottomSheet } from "@features/screening/components/IneligibleSurveyBottomSheet";
 import { getScreenings } from "@features/survey/service/surveyParticipation/api";
 import { mapOngoingSurveySummaryToSurveyListItem } from "@features/survey-list/hooks/useProcessedOngoingSurveys";
 import { useSurveyOpenStats } from "@features/survey-list/hooks/useSurveyOpenStats";
@@ -15,7 +14,7 @@ import { getMemberInfo } from "@shared/service/userInfo/api";
 import type { LocationStateWithReturnTo } from "@shared/types/navigation";
 import { adaptive } from "@toss/tds-colors";
 import { Asset, Button, FixedBottomCTA, Text } from "@toss/tds-mobile";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
 /** 세그먼트 조건을 만족하는 설문만 대상으로 최고 프로모션가 설문 선택 */
@@ -34,11 +33,6 @@ export const Intro = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const returnTo = (location.state as LocationStateWithReturnTo)?.returnTo;
-	const [ineligibleSurveySheet, setIneligibleSurveySheet] = useState<{
-		open: boolean;
-		title?: string;
-		description?: string;
-	}>({ open: false });
 
 	const { data: openStats, isPending: isOpenStatsPending } =
 		useSurveyOpenStats();
@@ -172,21 +166,12 @@ export const Intro = () => {
 				targetSummary = pickHighestPriceAmongEligible(surveys);
 			} catch (error) {
 				console.error("진행 설문 목록 조회 실패:", error);
-				setIneligibleSurveySheet({
-					open: true,
-					title: "설문 목록을 불러오지 못했어요",
-					description:
-						"잠시 후 다시 시도하거나, 하단 다음 버튼으로 홈에서 확인해 주세요.",
-				});
+				navigate("/home", { replace: true });
 				return;
 			}
 
 			if (!targetSummary) {
-				setIneligibleSurveySheet({
-					open: true,
-					title: "지금 참여할 수 있는 설문이 없어요",
-					description: `로그인 후 조건에 맞는 설문이 없어요. \n새 설문이 열리면 홈에서 참여할 수 있어요.`,
-				});
+				navigate("/home", { replace: true });
 				return;
 			}
 
@@ -365,13 +350,6 @@ export const Intro = () => {
 			>
 				다음
 			</FixedBottomCTA>
-
-			<IneligibleSurveyBottomSheet
-				open={ineligibleSurveySheet.open}
-				title={ineligibleSurveySheet.title}
-				description={ineligibleSurveySheet.description}
-				onClose={() => setIneligibleSurveySheet({ open: false })}
-			/>
 		</section>
 	);
 };

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -181,6 +181,7 @@ export const Intro = () => {
 
 			const surveyItem = mapOngoingSurveySummaryToSurveyListItem(summary);
 			let hasScreening = false;
+			let screeningLookupFailed = false;
 			try {
 				const screeningsData = await getScreenings({
 					lastSurveyId: 0,
@@ -191,6 +192,12 @@ export const Intro = () => {
 				);
 			} catch (error) {
 				console.error("스크리닝 목록 조회 실패:", error);
+				screeningLookupFailed = true;
+			}
+
+			if (screeningLookupFailed) {
+				navigate("/home", { replace: true });
+				return;
 			}
 
 			const surveyReturnTo = hasScreening

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -234,7 +234,7 @@ export const Intro = () => {
 
 	return (
 		<section
-			className="flex flex-col w-full mx-auto min-h-screen"
+			className="flex flex-col w-full mx-auto min-h-screen justify-center"
 			style={{
 				background:
 					"linear-gradient(to bottom, #FFFFFF 0%, #FFFFFF 15%, #C4E4D8 65%, #FFFFFF 100%)",

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -1,6 +1,13 @@
 import { appLogin } from "@apps-in-toss/web-framework";
-import { useAllOngoingSurveys } from "@features/survey-list/hooks/useAllOngoingSurveys";
+import { IneligibleSurveyBottomSheet } from "@features/screening/components/IneligibleSurveyBottomSheet";
+import { getScreenings } from "@features/survey/service/surveyParticipation/api";
+import { mapOngoingSurveySummaryToSurveyListItem } from "@features/survey-list/hooks/useProcessedOngoingSurveys";
+import { useSurveyOpenStats } from "@features/survey-list/hooks/useSurveyOpenStats";
+import { getAllOngoingSurveys } from "@features/survey-list/service/surveyList";
+import type { OngoingSurveySummary } from "@features/survey-list/service/surveyList/types";
+import { queryClient } from "@shared/contexts/queryClient";
 import { pushGtmEvent } from "@shared/lib/gtm";
+import { trackEvent } from "@shared/lib/mixpanel";
 import { saveTokens } from "@shared/lib/tokenManager";
 import { sendUserInfoEvent } from "@shared/lib/userInfoEvent";
 import { loginApi } from "@shared/service/login";
@@ -8,16 +15,37 @@ import { getMemberInfo } from "@shared/service/userInfo/api";
 import type { LocationStateWithReturnTo } from "@shared/types/navigation";
 import { adaptive } from "@toss/tds-colors";
 import { Asset, Button, FixedBottomCTA, Text } from "@toss/tds-mobile";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+
+/** 세그먼트 조건을 만족하는 설문만 대상으로 최고 프로모션가 설문 선택 */
+function pickHighestPriceAmongEligible(
+	list: OngoingSurveySummary[],
+): OngoingSurveySummary | undefined {
+	const eligible = list.filter((s) => s.isEligible ?? false);
+	if (eligible.length === 0) return undefined;
+	const maxPrice = Math.max(...eligible.map((s) => s.price ?? 0));
+	const tied = eligible.filter((s) => (s.price ?? 0) === maxPrice);
+	tied.sort((a, b) => a.surveyId - b.surveyId);
+	return tied[0];
+}
 
 export const Intro = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const returnTo = (location.state as LocationStateWithReturnTo)?.returnTo;
-	const { data: allOngoingSurveysData } = useAllOngoingSurveys();
-	const ongoingSurveyCount = allOngoingSurveysData?.surveys?.length ?? 0;
-	const hasOngoingSurvey = ongoingSurveyCount > 0;
+	const [isIneligibleBottomSheetOpen, setIsIneligibleBottomSheetOpen] =
+		useState(false);
+
+	const { data: openStats, isPending: isOpenStatsPending } =
+		useSurveyOpenStats();
+
+	const openSurveyCount = openStats?.openSurveyCount ?? 0;
+	const maxRewardCoin = openStats?.maxRewardCoin ?? 0;
+
+	const hasOngoingSurvey = !isOpenStatsPending && openSurveyCount > 0;
+
+	const surveyPromoText = `${maxRewardCoin.toLocaleString()}코인 설문 ${openSurveyCount}개 오픈,\n바로 설문에 참여해 보세요!`;
 
 	// 이전에 로그인한 사용자인지 확인
 	useEffect(() => {
@@ -83,12 +111,135 @@ export const Intro = () => {
 		}
 	};
 
+	const navigateToSurveyInfo = (
+		surveyItem: ReturnType<typeof mapOngoingSurveySummaryToSurveyListItem>,
+	) => {
+		pushGtmEvent({
+			event: "survey_start",
+			pagePath: "/survey",
+			survey_id: String(surveyItem.id),
+			source: "intro",
+		});
+		trackEvent("Survey Started", {
+			pagePath: "/survey",
+			surveyId: String(surveyItem.id),
+			source: "intro",
+			hasScreening: false,
+		});
+		const searchParams = new URLSearchParams({ surveyId: surveyItem.id });
+		navigate(
+			{
+				pathname: "/survey",
+				search: `?${searchParams.toString()}`,
+			},
+			{
+				replace: true,
+				state: { surveyId: surveyItem.id, survey: surveyItem },
+			},
+		);
+	};
+
+	const handleParticipateLogin = async () => {
+		pushGtmEvent({
+			event: "login",
+			pagePath: "/intro",
+			method: "로그인 수단 (Toss)",
+		});
+
+		try {
+			const { authorizationCode, referrer } = await appLogin();
+			const loginApiResponse = await loginApi(authorizationCode, referrer);
+			if (!loginApiResponse.accessToken || !loginApiResponse.refreshToken) {
+				return;
+			}
+
+			await saveTokens(
+				loginApiResponse.accessToken,
+				loginApiResponse.refreshToken,
+			);
+			void sendUserInfoEvent("Toss");
+
+			let targetSummary: OngoingSurveySummary | undefined;
+			let listedSurveyCount = 0;
+			try {
+				const result = await getAllOngoingSurveys({
+					lastSurveyId: 0,
+					size: 100,
+				});
+				const surveys = result.surveys ?? [];
+				listedSurveyCount = surveys.length;
+				targetSummary = pickHighestPriceAmongEligible(surveys);
+			} catch (error) {
+				console.error("진행 설문 목록 조회 실패:", error);
+				navigate("/home", { replace: true });
+				return;
+			}
+
+			if (!targetSummary) {
+				if (listedSurveyCount > 0) {
+					setIsIneligibleBottomSheetOpen(true);
+				} else {
+					navigate("/home", { replace: true });
+				}
+				return;
+			}
+
+			const summary = targetSummary;
+
+			void queryClient.invalidateQueries({ queryKey: ["allOngoingSurveys"] });
+
+			const surveyItem = mapOngoingSurveySummaryToSurveyListItem(summary);
+			let hasScreening = false;
+			try {
+				const screeningsData = await getScreenings({
+					lastSurveyId: 0,
+					size: 100,
+				});
+				hasScreening = (screeningsData.data ?? []).some(
+					(s) => s.surveyId === summary.surveyId,
+				);
+			} catch (error) {
+				console.error("스크리닝 목록 조회 실패:", error);
+			}
+
+			const surveyReturnTo = hasScreening
+				? {
+						path: `/oxScreening?surveyId=${surveyItem.id}`,
+						state: undefined,
+					}
+				: {
+						path: `/survey?surveyId=${surveyItem.id}`,
+						state: {
+							surveyId: surveyItem.id,
+							survey: surveyItem,
+						} as Record<string, unknown>,
+					};
+
+			if (loginApiResponse.onboardingCompleted) {
+				if (hasScreening) {
+					navigate(`/oxScreening?surveyId=${surveyItem.id}`, {
+						replace: true,
+					});
+				} else {
+					navigateToSurveyInfo(surveyItem);
+				}
+			} else {
+				navigate("/onboarding", {
+					replace: true,
+					state: { returnTo: surveyReturnTo },
+				});
+			}
+		} catch (error) {
+			console.error("토스 로그인 실패:", error);
+		}
+	};
+
 	return (
 		<section
 			className="flex flex-col w-full mx-auto min-h-screen"
 			style={{
 				background:
-					"linear-gradient(to bottom, #FFFFFF 0%, #D7EDE4 15%, #C4E4D8 100%)",
+					"linear-gradient(to bottom, #FFFFFF 0%, #FFFFFF 15%, #C4E4D8 65%, #FFFFFF 100%)",
 			}}
 		>
 			<div
@@ -175,19 +326,23 @@ export const Intro = () => {
 						className="mt-6 relative rounded-3xl bg-white px-5 py-5 flex items-center justify-between gap-4"
 						style={{ boxShadow: "0 8px 20px #D7EDE4" }}
 					>
-						<Text color={adaptive.grey800} typography="st4" fontWeight="bold">
-							{`400원 설문 ${ongoingSurveyCount}개 오픈,\n바로 설문에 참여해 보세요!`}
+						<Text
+							color={adaptive.grey700}
+							typography="t6"
+							fontWeight="semibold"
+						>
+							{surveyPromoText}
 						</Text>
 						<Button
 							variant="weak"
-							size="small"
+							size="medium"
 							style={
 								{
 									"--button-background-color": "#E8F8F0",
 									"--button-text-color": "#15c67f",
 								} as React.CSSProperties
 							}
-							onClick={handleLogin}
+							onClick={handleParticipateLogin}
 						>
 							참여하기
 						</Button>
@@ -204,6 +359,11 @@ export const Intro = () => {
 			>
 				다음
 			</FixedBottomCTA>
+
+			<IneligibleSurveyBottomSheet
+				open={isIneligibleBottomSheetOpen}
+				onClose={() => setIsIneligibleBottomSheetOpen(false)}
+			/>
 		</section>
 	);
 };

--- a/src/app/Intro.tsx
+++ b/src/app/Intro.tsx
@@ -1,12 +1,13 @@
 import { appLogin } from "@apps-in-toss/web-framework";
+import { useAllOngoingSurveys } from "@features/survey-list/hooks/useAllOngoingSurveys";
 import { pushGtmEvent } from "@shared/lib/gtm";
 import { saveTokens } from "@shared/lib/tokenManager";
 import { sendUserInfoEvent } from "@shared/lib/userInfoEvent";
 import { loginApi } from "@shared/service/login";
 import { getMemberInfo } from "@shared/service/userInfo/api";
 import type { LocationStateWithReturnTo } from "@shared/types/navigation";
-import { colors } from "@toss/tds-colors";
-import { Asset, FixedBottomCTA, StepperRow, Top } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import { Asset, Button, FixedBottomCTA, Text } from "@toss/tds-mobile";
 import { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 
@@ -14,6 +15,9 @@ export const Intro = () => {
 	const navigate = useNavigate();
 	const location = useLocation();
 	const returnTo = (location.state as LocationStateWithReturnTo)?.returnTo;
+	const { data: allOngoingSurveysData } = useAllOngoingSurveys();
+	const ongoingSurveyCount = allOngoingSurveysData?.surveys?.length ?? 0;
+	const hasOngoingSurvey = ongoingSurveyCount > 0;
 
 	// 이전에 로그인한 사용자인지 확인
 	useEffect(() => {
@@ -80,45 +84,116 @@ export const Intro = () => {
 	};
 
 	return (
-		<section className="flex flex-col w-full mx-auto">
-			<Top
-				title={
-					<Top.TitleParagraph size={22} color={colors.grey900}>
-						설문조사 참여하고 포인트 받아가세요
-					</Top.TitleParagraph>
-				}
-			/>
-			<div className="flex justify-center items-center my-10">
-				<Asset.Image
-					frameShape={{ width: 160, height: 160 }}
-					backgroundColor="transparent"
-					src="https://static.toss.im/ml-product/typing-laptop-apng.png"
-					aria-hidden={true}
-				/>
-			</div>
-			<StepperRow
-				left={<StepperRow.NumberIcon number={1} />}
-				center={
-					<StepperRow.Texts
-						type="B"
-						title="설문조사에 참여해요"
-						description=""
+		<section
+			className="flex flex-col w-full mx-auto min-h-screen"
+			style={{
+				background:
+					"linear-gradient(to bottom, #FFFFFF 0%, #D7EDE4 15%, #C4E4D8 100%)",
+			}}
+		>
+			<div
+				className={`px-4 ${hasOngoingSurvey ? "my-8" : "flex-1 flex flex-col justify-center"}`}
+			>
+				<div className="flex justify-center items-center mb-6">
+					<Asset.Image
+						frameShape={{ width: 160, height: 160 }}
+						backgroundColor="transparent"
+						src="https://static.toss.im/ml-product/typing-laptop-apng.png"
+						aria-hidden={true}
 					/>
-				}
-			/>
-			<StepperRow
-				left={<StepperRow.NumberIcon number={2} />}
-				center={
-					<StepperRow.Texts type="B" title="성실하게 응답하고" description="" />
-				}
-			/>
-			<StepperRow
-				left={<StepperRow.NumberIcon number={3} />}
-				center={
-					<StepperRow.Texts type="B" title="포인트를 적립해요" description="" />
-				}
-				hideLine={true}
-			/>
+				</div>
+
+				<Text
+					display="block"
+					color={adaptive.grey800}
+					typography="st5"
+					fontWeight="bold"
+					textAlign="center"
+				>
+					설문 통합 플랫폼 온서베이
+				</Text>
+
+				<div className="mt-6 grid grid-cols-3 gap-3">
+					<div className="rounded-3xl! bg-white px-3 py-5 flex flex-col items-center gap-3">
+						<Asset.Icon
+							frameShape={Asset.frameShape.CleanW40}
+							backgroundColor="transparent"
+							name="icon-document-folder-yellow-check"
+							aria-hidden={true}
+							ratio="1/1"
+						/>
+						<Text
+							display="block"
+							color={adaptive.grey800}
+							typography="t5"
+							fontWeight="semibold"
+							textAlign="center"
+						>
+							설문 업로드 시 빠른 응답
+						</Text>
+					</div>
+					<div className="rounded-3xl bg-white px-3 py-5 flex flex-col items-center gap-3">
+						<Asset.Icon
+							frameShape={Asset.frameShape.CleanW40}
+							backgroundColor="transparent"
+							name="icon-money-bag-green-weak"
+							aria-hidden={true}
+							ratio="1/1"
+						/>
+						<Text
+							display="block"
+							color={adaptive.grey800}
+							typography="t5"
+							fontWeight="semibold"
+							textAlign="center"
+						>
+							설문 참여 시 리워드
+						</Text>
+					</div>
+					<div className="rounded-3xl bg-white px-3 py-5 flex flex-col items-center gap-3">
+						<Asset.Image
+							frameShape={Asset.frameShape.CleanW40}
+							backgroundColor="transparent"
+							src="https://static.toss.im/2d-emojis/png/4x/u1F517.png"
+							aria-hidden={true}
+							style={{ aspectRatio: "1/1" }}
+						/>
+						<Text
+							display="block"
+							color={adaptive.grey800}
+							typography="t5"
+							fontWeight="semibold"
+							textAlign="center"
+						>
+							부담없는 구글폼 변환
+						</Text>
+					</div>
+				</div>
+
+				{hasOngoingSurvey && (
+					<div
+						className="mt-6 relative rounded-3xl bg-white px-5 py-5 flex items-center justify-between gap-4"
+						style={{ boxShadow: "0 8px 20px #D7EDE4" }}
+					>
+						<Text color={adaptive.grey800} typography="st4" fontWeight="bold">
+							{`400원 설문 ${ongoingSurveyCount}개 오픈,\n바로 설문에 참여해 보세요!`}
+						</Text>
+						<Button
+							variant="weak"
+							size="small"
+							style={
+								{
+									"--button-background-color": "#E8F8F0",
+									"--button-text-color": "#15c67f",
+								} as React.CSSProperties
+							}
+							onClick={handleLogin}
+						>
+							참여하기
+						</Button>
+					</div>
+				)}
+			</div>
 
 			<FixedBottomCTA
 				loading={false}

--- a/src/features/screening/components/IneligibleSurveyBottomSheet.tsx
+++ b/src/features/screening/components/IneligibleSurveyBottomSheet.tsx
@@ -4,27 +4,38 @@ import { useNavigate } from "react-router-dom";
 interface IneligibleSurveyBottomSheetProps {
 	open: boolean;
 	onClose: () => void;
+	/** 미입력 시 목록에서 단일 설문 비대상 안내 문구 */
+	title?: string;
+	description?: string;
+	/** false면 확인 시 홈으로 이동하지 않고 닫기만 (인트로 등) */
+	confirmNavigatesHome?: boolean;
 }
+
+const DEFAULT_TITLE = "해당 설문에 참여할 수 없어요";
+const DEFAULT_DESCRIPTION = "조건이 맞지 않아 설문 참여가 불가능해요";
 
 export const IneligibleSurveyBottomSheet = ({
 	open,
 	onClose,
+	title = DEFAULT_TITLE,
+	description = DEFAULT_DESCRIPTION,
+	confirmNavigatesHome = true,
 }: IneligibleSurveyBottomSheetProps) => {
 	const navigate = useNavigate();
 
 	const handleConfirm = () => {
+		if (confirmNavigatesHome) {
+			navigate("/home");
+		}
 		onClose();
-		navigate("/home");
 	};
 
 	return (
 		<BottomSheet
-			header={
-				<BottomSheet.Header>해당 설문에 참여할 수 없어요</BottomSheet.Header>
-			}
+			header={<BottomSheet.Header>{title}</BottomSheet.Header>}
 			headerDescription={
 				<BottomSheet.HeaderDescription>
-					조건이 맞지 않아 설문 참여가 불가능해요
+					{description}
 				</BottomSheet.HeaderDescription>
 			}
 			open={open}

--- a/src/features/survey-list/hooks/useAllOngoingSurveys.ts
+++ b/src/features/survey-list/hooks/useAllOngoingSurveys.ts
@@ -1,9 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { getAllOngoingSurveys } from "../service/surveyList";
 
-export const useAllOngoingSurveys = () => {
+export const useAllOngoingSurveys = (options?: { enabled?: boolean }) => {
 	return useQuery({
 		queryKey: ["allOngoingSurveys"],
 		queryFn: () => getAllOngoingSurveys({ lastSurveyId: 0, size: 100 }), // 충분히 큰 size로 모든 설문 가져오기
+		enabled: options?.enabled ?? true,
 	});
 };

--- a/src/features/survey-list/hooks/useProcessedOngoingSurveys.ts
+++ b/src/features/survey-list/hooks/useProcessedOngoingSurveys.ts
@@ -7,6 +7,33 @@ import { useMemo } from "react";
 
 const DEFAULT_TOPIC: SurveyListItem["topicId"] = "DAILY_LIFE";
 
+export const mapOngoingSurveySummaryToSurveyListItem = (
+	survey: OngoingSurveySummary,
+): SurveyListItem => {
+	const topicId =
+		(survey.interests && survey.interests.length > 0
+			? survey.interests[0]
+			: survey.interest) ?? DEFAULT_TOPIC;
+	const topic = topics.find((t) => t.id === topicId);
+	const iconSrc = topic?.icon.type === "image" ? topic.icon.src : undefined;
+
+	const remainingTime = formatRemainingTime(survey.deadline);
+	return {
+		id: String(survey.surveyId),
+		topicId: topicId as SurveyListItem["topicId"],
+		title: survey.title,
+		iconType: iconSrc ? "image" : "icon",
+		iconSrc,
+		iconName: topic?.icon.type === "icon" ? topic.icon.name : undefined,
+		description: survey.description,
+		remainingTimeText: remainingTime,
+		isClosed: remainingTime === "마감됨",
+		isFree: survey.isFree,
+		responseCount: survey.responseCount,
+		price: survey.price,
+	};
+};
+
 /** 훅 반환값: 추천/임박 리스트와 프로모션 총액 */
 export interface ProcessedOngoingSurveysResult {
 	recommended: SurveyListItem[];
@@ -31,31 +58,6 @@ export const useProcessedOngoingSurveys = (
 			};
 		}
 
-		const mapSurveyToItem = (survey: OngoingSurveySummary): SurveyListItem => {
-			const topicId =
-				(survey.interests && survey.interests.length > 0
-					? survey.interests[0]
-					: survey.interest) ?? DEFAULT_TOPIC;
-			const topic = topics.find((t) => t.id === topicId);
-			const iconSrc = topic?.icon.type === "image" ? topic.icon.src : undefined;
-
-			const remainingTime = formatRemainingTime(survey.deadline);
-			return {
-				id: String(survey.surveyId),
-				topicId: topicId as SurveyListItem["topicId"],
-				title: survey.title,
-				iconType: iconSrc ? "image" : "icon",
-				iconSrc,
-				iconName: topic?.icon.type === "icon" ? topic.icon.name : undefined,
-				description: survey.description,
-				remainingTimeText: remainingTime,
-				isClosed: remainingTime === "마감됨",
-				isFree: survey.isFree,
-				responseCount: survey.responseCount,
-				price: survey.price,
-			};
-		};
-
 		const filterClosedSurveys = (surveys?: OngoingSurveySummary[]) => {
 			if (!surveys) return [];
 			return surveys.filter((survey) => {
@@ -67,8 +69,10 @@ export const useProcessedOngoingSurveys = (
 		const filteredRecommended = filterClosedSurveys(result.recommended);
 		const filteredImpending = filterClosedSurveys(result.impending);
 
-		const rec = filteredRecommended.map(mapSurveyToItem);
-		const imp = filteredImpending.map(mapSurveyToItem);
+		const rec = filteredRecommended.map(
+			mapOngoingSurveySummaryToSurveyListItem,
+		);
+		const imp = filteredImpending.map(mapOngoingSurveySummaryToSurveyListItem);
 
 		const uniqueSurveyIds = getUniqueSurveyIdsFromArrays(
 			result.recommended,

--- a/src/features/survey-list/hooks/useSurveyOpenStats.ts
+++ b/src/features/survey-list/hooks/useSurveyOpenStats.ts
@@ -1,0 +1,9 @@
+import { useQuery } from "@tanstack/react-query";
+import { getSurveyOpenStats } from "../service/surveyList";
+
+export const useSurveyOpenStats = () => {
+	return useQuery({
+		queryKey: ["surveyOpenStats"],
+		queryFn: getSurveyOpenStats,
+	});
+};

--- a/src/features/survey-list/service/surveyList/api.ts
+++ b/src/features/survey-list/service/surveyList/api.ts
@@ -5,6 +5,7 @@ import type {
 	ImpendingSurveyResult,
 	OngoingSurveyResult,
 	RecommendedSurveyResult,
+	SurveyOpenStats,
 } from "./types";
 
 export interface GetOngoingSurveysParams {
@@ -90,5 +91,13 @@ export const getGlobalStats = async (): Promise<GlobalStats> => {
 	return apiCall<GlobalStats>({
 		method: "GET",
 		url: "/v1/surveys/global-stats",
+	});
+};
+
+/** 비인증: 열린 설문 수 + 최대 리워드 코인 */
+export const getSurveyOpenStats = async (): Promise<SurveyOpenStats> => {
+	return apiCall<SurveyOpenStats>({
+		method: "GET",
+		url: "/v1/surveys/open-stats",
 	});
 };

--- a/src/features/survey-list/service/surveyList/types.ts
+++ b/src/features/survey-list/service/surveyList/types.ts
@@ -45,6 +45,12 @@ export interface OngoingSurveyResponse extends BaseResponse {
 	result: OngoingSurveyResult;
 }
 
+/** GET /v1/surveys/open-stats — 비인증, 노출 가능 설문 수 + 최대 리워드 코인 */
+export interface SurveyOpenStats {
+	openSurveyCount: number;
+	maxRewardCoin: number;
+}
+
 export interface GlobalStats {
 	totalDueCount: number;
 	totalCompletedCount: number;

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -38,8 +38,18 @@ export interface SectionBasedSurveyState {
 export function useSectionBasedSurveyController() {
 	const navigate = useNavigate();
 	const { openToast } = useToast();
-	const { numericSurveyId, locationState: routeState } = useSurveyRouteParams();
+	const {
+		numericSurveyId,
+		locationState: routeState,
+		priceFromState,
+	} = useSurveyRouteParams();
 	const locationState = routeState as SectionBasedSurveyState | undefined;
+
+	const rawRewardPrice = locationState?.price ?? priceFromState;
+	const rewardPriceDisplay =
+		rawRewardPrice != null && Number.isFinite(Number(rawRewardPrice))
+			? Number(rawRewardPrice)
+			: 200;
 	const surveyId = numericSurveyId ?? locationState?.surveyId ?? null;
 
 	const [currentSection, setCurrentSection] = useState(
@@ -457,6 +467,7 @@ export function useSectionBasedSurveyController() {
 	return {
 		headerTitleText,
 		headerSubtitleText,
+		rewardPriceDisplay,
 		currentSection,
 		sectionCount: surveySectionCount,
 		progress:

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -20,6 +20,7 @@ import { useSurveySectionQuestions } from "./useSurveySectionQuestions";
 export interface SectionBasedSurveyState {
 	surveyId: number;
 	currentSection: number;
+	sectionCount?: number;
 	answers: Record<number, string>;
 	previousAnswers: Record<number, string>;
 	surveyTitle?: string;
@@ -116,6 +117,24 @@ export function useSectionBasedSurveyController() {
 	const [nextLoading, setNextLoading] = useState(false);
 
 	const { mutateAsync: completeSurveyMutation } = useCompleteSurvey();
+	const [surveySectionCount, setSurveySectionCount] = useState<
+		number | undefined
+	>(locationState?.sectionCount);
+
+	useEffect(() => {
+		if (!surveyId || surveySectionCount != null) return;
+
+		void (async () => {
+			try {
+				const info = await getSurveyInfo(surveyId);
+				if (typeof info.sectionCount === "number") {
+					setSurveySectionCount(info.sectionCount);
+				}
+			} catch {
+				// 진행 바 표시를 위한 보조 정보이므로 조회 실패 시 무시
+			}
+		})();
+	}, [surveyId, surveySectionCount]);
 
 	useEffect(() => {
 		if (!data?.info.length) return;
@@ -426,6 +445,12 @@ export function useSectionBasedSurveyController() {
 	return {
 		headerTitleText,
 		headerSubtitleText,
+		currentSection,
+		sectionCount: surveySectionCount,
+		progress:
+			typeof surveySectionCount === "number" && surveySectionCount > 0
+				? Math.min(currentSection / surveySectionCount, 1)
+				: 0,
 		canSkipEmptySectionForward,
 		questions,
 		answers,
@@ -441,6 +466,7 @@ export function useSectionBasedSurveyController() {
 		handleNext,
 		handleSubmitClick,
 		isLastSection,
+		isBeforeSubmitStep: isLastSection,
 		submitting,
 		nextLoading,
 		isPending,

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -82,14 +82,12 @@ export function useSectionBasedSurveyController() {
 		nextSectionFromApi,
 	);
 
-	const decidableBranchQuestion = questions.find(
-		(q) => q.isSectionDecidable && q.type === "multipleChoice",
+	const awaitingDecidableBranch = questions.some(
+		(q) =>
+			q.isSectionDecidable &&
+			q.type === "multipleChoice" &&
+			isMultipleChoiceAnswerEmpty(answersRef.current[q.questionId]),
 	);
-	const awaitingDecidableBranch =
-		decidableBranchQuestion !== undefined &&
-		isMultipleChoiceAnswerEmpty(
-			answersRef.current[decidableBranchQuestion.questionId],
-		);
 
 	const isLastSection = actualNextSection === 0 && !awaitingDecidableBranch;
 

--- a/src/features/survey/hooks/useSectionBasedSurveyController.ts
+++ b/src/features/survey/hooks/useSectionBasedSurveyController.ts
@@ -17,6 +17,11 @@ import { useCompleteSurvey } from "./useCompleteSurvey";
 import { useSurveyRouteParams } from "./useSurveyRouteParams";
 import { useSurveySectionQuestions } from "./useSurveySectionQuestions";
 
+function isMultipleChoiceAnswerEmpty(raw: string | undefined): boolean {
+	if (raw === undefined) return true;
+	return raw.split("|||").filter(Boolean).length === 0;
+}
+
 export interface SectionBasedSurveyState {
 	surveyId: number;
 	currentSection: number;
@@ -77,7 +82,16 @@ export function useSectionBasedSurveyController() {
 		nextSectionFromApi,
 	);
 
-	const isLastSection = actualNextSection === 0;
+	const decidableBranchQuestion = questions.find(
+		(q) => q.isSectionDecidable && q.type === "multipleChoice",
+	);
+	const awaitingDecidableBranch =
+		decidableBranchQuestion !== undefined &&
+		isMultipleChoiceAnswerEmpty(
+			answersRef.current[decidableBranchQuestion.questionId],
+		);
+
+	const isLastSection = actualNextSection === 0 && !awaitingDecidableBranch;
 
 	const canSkipEmptySectionForward =
 		questions.length === 0 &&
@@ -127,8 +141,8 @@ export function useSectionBasedSurveyController() {
 		void (async () => {
 			try {
 				const info = await getSurveyInfo(surveyId);
-				if (typeof info.sectionCount === "number") {
-					setSurveySectionCount(info.sectionCount);
+				if (typeof info.totalSections === "number") {
+					setSurveySectionCount(info.totalSections);
 				}
 			} catch {
 				// 진행 바 표시를 위한 보조 정보이므로 조회 실패 시 무시

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -17,6 +17,7 @@ export const SectionBasedSurvey = () => {
 	const {
 		headerTitleText,
 		headerSubtitleText,
+		rewardPriceDisplay,
 		progress,
 		sectionCount,
 		questions,
@@ -89,7 +90,8 @@ export const SectionBasedSurvey = () => {
 									typography="t6"
 									fontWeight="semibold"
 								>
-									잘 하고 있어요! 곧 400원 획득!
+									잘 하고 있어요! 곧{" "}
+									{rewardPriceDisplay.toLocaleString("ko-KR")}원 획득!
 								</Text>
 							</>
 						)}

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -1,8 +1,11 @@
 import { adaptive } from "@toss/tds-colors";
 import {
+	Asset,
 	Border,
 	CTAButton,
 	FixedBottomCTA,
+	ProgressBar,
+	Text,
 	Top,
 	WheelDatePicker,
 } from "@toss/tds-mobile";
@@ -14,6 +17,8 @@ export const SectionBasedSurvey = () => {
 	const {
 		headerTitleText,
 		headerSubtitleText,
+		progress,
+		sectionCount,
 		questions,
 		answers,
 		updateAnswer,
@@ -28,14 +33,64 @@ export const SectionBasedSurvey = () => {
 		handleNext,
 		handleSubmitClick,
 		isLastSection,
+		isBeforeSubmitStep,
 		submitting,
 		nextLoading,
 		isPending,
 		canSkipEmptySectionForward,
 	} = useSectionBasedSurveyController();
 
+	const showMilestoneMessage = (sectionCount ?? 0) >= 4 && !isBeforeSubmitStep;
+	const showFinalStretchMessage = isBeforeSubmitStep;
+
 	return (
 		<>
+			<ProgressBar
+				size="normal"
+				color={adaptive.green500}
+				progress={progress}
+			/>
+			{(showMilestoneMessage || showFinalStretchMessage) && (
+				<div className="px-4 mt-4 mb-2 flex items-center gap-2">
+					{showFinalStretchMessage ? (
+						<>
+							<Asset.Icon
+								frameShape={Asset.frameShape.CleanW24}
+								backgroundColor="transparent"
+								name="icon-place-cheer-exam-1"
+								aria-hidden={true}
+								ratio="12/11"
+							/>
+							<Text
+								display="block"
+								color={adaptive.green800}
+								typography="t6"
+								fontWeight="semibold"
+							>
+								거의 다 왔어요. 조금만 힘내세요!
+							</Text>
+						</>
+					) : (
+						<>
+							<Asset.Icon
+								frameShape={Asset.frameShape.CleanW24}
+								backgroundColor="transparent"
+								name="icon-check-circle-green-fill"
+								aria-hidden={true}
+								ratio="1/1"
+							/>
+							<Text
+								display="block"
+								color={adaptive.green800}
+								typography="t6"
+								fontWeight="semibold"
+							>
+								잘 하고 있어요! 곧 400원 획득!
+							</Text>
+						</>
+					)}
+				</div>
+			)}
 			<Top
 				title={
 					headerTitleText ? (

--- a/src/features/survey/pages/SectionBasedSurvey.tsx
+++ b/src/features/survey/pages/SectionBasedSurvey.tsx
@@ -51,44 +51,49 @@ export const SectionBasedSurvey = () => {
 				progress={progress}
 			/>
 			{(showMilestoneMessage || showFinalStretchMessage) && (
-				<div className="px-4 mt-4 mb-2 flex items-center gap-2">
-					{showFinalStretchMessage ? (
-						<>
-							<Asset.Icon
-								frameShape={Asset.frameShape.CleanW24}
-								backgroundColor="transparent"
-								name="icon-place-cheer-exam-1"
-								aria-hidden={true}
-								ratio="12/11"
-							/>
-							<Text
-								display="block"
-								color={adaptive.green800}
-								typography="t6"
-								fontWeight="semibold"
-							>
-								거의 다 왔어요. 조금만 힘내세요!
-							</Text>
-						</>
-					) : (
-						<>
-							<Asset.Icon
-								frameShape={Asset.frameShape.CleanW24}
-								backgroundColor="transparent"
-								name="icon-check-circle-green-fill"
-								aria-hidden={true}
-								ratio="1/1"
-							/>
-							<Text
-								display="block"
-								color={adaptive.green800}
-								typography="t6"
-								fontWeight="semibold"
-							>
-								잘 하고 있어요! 곧 400원 획득!
-							</Text>
-						</>
-					)}
+				<div className="px-4 mt-4 mb-2">
+					<div
+						className="flex items-center gap-2 rounded-2xl px-4 py-3"
+						style={{ backgroundColor: adaptive.green50 }}
+					>
+						{showFinalStretchMessage ? (
+							<>
+								<Asset.Icon
+									frameShape={Asset.frameShape.CleanW24}
+									backgroundColor="transparent"
+									name="icon-place-cheer-exam-1"
+									aria-hidden={true}
+									ratio="12/11"
+								/>
+								<Text
+									display="block"
+									color={adaptive.green800}
+									typography="t6"
+									fontWeight="semibold"
+								>
+									거의 다 왔어요. 조금만 힘내세요!
+								</Text>
+							</>
+						) : (
+							<>
+								<Asset.Icon
+									frameShape={Asset.frameShape.CleanW24}
+									backgroundColor="transparent"
+									name="icon-check-circle-green-fill"
+									aria-hidden={true}
+									ratio="1/1"
+								/>
+								<Text
+									display="block"
+									color={adaptive.green800}
+									typography="t6"
+									fontWeight="semibold"
+								>
+									잘 하고 있어요! 곧 400원 획득!
+								</Text>
+							</>
+						)}
+					</div>
 				</div>
 			)}
 			<Top

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -259,7 +259,7 @@ export const Survey = () => {
 			state: {
 				surveyId: numericSurveyId,
 				currentSection: 1,
-				sectionCount: surveyBasicInfoData?.sectionCount,
+				sectionCount: surveyBasicInfoData?.totalSections,
 				answers: {},
 				previousAnswers: {},
 				surveyTitle: surveyTitle ?? "",

--- a/src/features/survey/pages/Survey.tsx
+++ b/src/features/survey/pages/Survey.tsx
@@ -259,6 +259,7 @@ export const Survey = () => {
 			state: {
 				surveyId: numericSurveyId,
 				currentSection: 1,
+				sectionCount: surveyBasicInfoData?.sectionCount,
 				answers: {},
 				previousAnswers: {},
 				surveyTitle: surveyTitle ?? "",

--- a/src/features/survey/service/surveyParticipation/types.ts
+++ b/src/features/survey/service/surveyParticipation/types.ts
@@ -184,6 +184,7 @@ export interface SurveyBasicInfo {
 	deadline: string;
 	interests: string[];
 	responseCount: number;
+	sectionCount?: number;
 	isScreenRequired: boolean;
 	isScreened: boolean;
 	isSurveyResponded: boolean;

--- a/src/features/survey/service/surveyParticipation/types.ts
+++ b/src/features/survey/service/surveyParticipation/types.ts
@@ -184,7 +184,7 @@ export interface SurveyBasicInfo {
 	deadline: string;
 	interests: string[];
 	responseCount: number;
-	sectionCount?: number;
+	totalSections?: number;
 	isScreenRequired: boolean;
 	isScreened: boolean;
 	isSurveyResponded: boolean;


### PR DESCRIPTION
# 📌 Feat: 인트로 설문 유입·open-stats 연동 및 섹션 설문 UX/분기 판정 개선

## 요약

인트로에서 비인증 사용자를 대상으로 공개 설문 통계(open-stats)를 노출하고, 로그인 이후 자연스럽게 설문 참여로 이어지는 플로우를 연결했습니다.
또한 섹션 설문 UI를 다듬고, 마지막 섹션 여부를 잘못 판정하던 분기 로직을 수정해 치어 메시지 및 제출 단계 판정 오류를 개선했습니다.

---

## 주요 변경 사항

### 인트로 · 공개 통계 API 연동

* `GET /v1/surveys/open-stats` 연동

  * `openSurveyCount`
  * `maxRewardCoin`
* `useSurveyOpenStats` 훅 추가
* 설문 배너 노출 조건 및 카피 개선

  * 오픈 설문 수
  * 최대 리워드 코인 기준 노출
* `참여하기` 액션 플로우 연결

  * 로그인 이후 `ongoing/all` 목록 조회
  * 참여 가능한(`isEligible`) 설문만 필터링
  * 최고 리워드 설문 우선 선택
  * 스크리닝 존재 시 `oxScreening`
  * 없을 경우 설문 `info`로 진입
* 참여 불가 또는 목록 조회 실패 시

  * 바텀시트 안내 노출
  * 확인 시 홈 이동 처리

---

### 설문 정보 API 타입 정리

* `SurveyBasicInfo`에 `totalSections` 반영
* 섹션 진행/네비게이션 state에서는 기존 `sectionCount` 키 유지

  * 단, 값은 `totalSections` 기준으로 사용하도록 정리

---

### 섹션 설문 UI 개선

* 프로그레스 바 하단 안내 영역 스타일 개선

  * 마일스톤 메시지
  * 마지막 구간 메시지
* 적용 스타일

  * background
  * border-radius
  * padding

---

## 🐞 버그 수정

### 마지막 섹션 오인 판정 수정

#### 문제

기존에는 아래 조건만으로 마지막 섹션 여부를 판단했습니다.

```ts
actualNextSection === 0
```

하지만 분기형 객관식 문항에서 아직 답변하지 않은 상태에서도 API가 `nextSection: 0`을 반환하는 경우가 있어, 실제 마지막 섹션이 아닌데도 종료 직전으로 오인되는 문제가 있었습니다.

#### 영향

* 아직 마지막이 아닌데도

  * `거의 다 왔어요` 메시지가 잠깐 노출됨
* 이후 선택값에 따라 분기가 결정되면

  * `잘 하고 있어요` 메시지와 혼재되어 보이는 현상 발생
* 동일 로직이 제출 단계(`isBeforeSubmitStep`) 판단에도 영향을 줄 가능성 존재

#### 대응

현재 섹션이 아래 조건을 만족하는 경우:

* `isSectionDecidable === true`
* 분기형 `multipleChoice` 문항 존재
* 아직 답변 없음

→ `awaitingDecidableBranch` 상태로 간주하도록 수정했습니다.

이 상태에서는 `isLastSection`을 `true`로 판단하지 않도록 변경해,
분기 확정 이전에 마지막 섹션으로 오인되지 않도록 처리했습니다.

---

## 🔗 관련 이슈

* Jira: https://onsurvey.atlassian.net/jira/software/projects/OMF/boards/35?selectedIssue=OMF-332

---

## ✅ 리뷰 요청 사항

* [x] 🙂 크게 우려되는 사항은 없어요. 가볍게 리뷰 부탁드립니다.
* [ ] ⚠️ 사이드 이펙트 가능성이 있어요. 자세히 봐주세요.
* [ ] 🤔 분기 판정 로직 변경이 적절한지 함께 확인 부탁드립니다.

---

## 🎨 스크린샷

<table>
  <tr>
    <th>페이지 1</th>
    <th>페이지 2</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/4f7437f7-84a5-420d-823d-03a80645f1b0" width="250" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/409bae46-1c69-4b38-bfcd-fc34f177ca09" width="250" />
    </td>
  </tr>
</table>

<br>

<table>
  <tr>
    <th>페이지 3</th>
    <th>페이지 4</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/e8795d52-5ae2-4e7b-9450-c0918f566648" width="250" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/d2301833-a7f6-49e0-8678-b9a1bf035b90" width="250" />
    </td>
  </tr>
</table>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 사용자를 위한 "참여하기" 흐름 추가 — 가장 높은 보상 설문 자동 선택 및 참여로 이동
  * 다중 섹션 설문용 진행도 표시줄 및 섹션 기반 마일스톤/최종 단계 메시지 추가
  * 열린 설문 수·최대 보상 코인 정보가 있는 프로모션 배너 추가

* **개선 사항**
  * 부적격 안내창에 제목/설명 커스터마이징 및 확인 동작 개선
  * 참여 중 에러/빈 결과 시 홈으로 안전하게 복귀하도록 처리 개선

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/On-Survey/Frontend/pull/162)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->